### PR TITLE
fix: switch Docker image from alpine to slim for sodium-native compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         run: docker build --build-arg VERSION=ci --build-arg REVISION=${{ github.sha }} -t couplecards:ci .
 
       - name: Check root dependency licenses
-        run: npx --yes license-checker --production --onlyAllow 'MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;OFL-1.1;CC0-1.0;Unlicense;0BSD;BlueOak-1.0.0' --excludePackages 'couplecards@1.0.0'
+        run: npx --yes license-checker --production --onlyAllow 'MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;OFL-1.1;CC0-1.0;Unlicense;0BSD;BlueOak-1.0.0' --excludePrivatePackages
 
       - name: Check server dependency licenses
         working-directory: server
         run: |
           npm install --omit=dev --no-audit --no-fund
-          npx --yes license-checker --production --onlyAllow 'MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;OFL-1.1;CC0-1.0;Unlicense;0BSD;BlueOak-1.0.0' --excludePackages 'couplecards-server@1.0.0'
+          npx --yes license-checker --production --onlyAllow 'MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;OFL-1.1;CC0-1.0;Unlicense;0BSD;BlueOak-1.0.0' --excludePrivatePackages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 _Nothing released yet._
+
+## [1.0.1] - 2026-04-23
+
+### Fixed
+
+- Container crashed on startup with `ADDON_NOT_FOUND` for `sodium-native` (pulled in by `@fastify/secure-session`). Switched the Docker image from `node:24-alpine` (musl) to `node:24-slim` (glibc) on all three build stages, since sodium-native's musl prebuilds are not reliably fetched by npm. Package manager calls (`apk` → `apt-get`), user creation (`adduser -S` → `useradd --system`), and the `tini` path (`/sbin/tini` → `/usr/bin/tini`) were adapted accordingly.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 # SPDX-License-Identifier: MIT
-# Multi-stage build. No native-addon compilation: the backend runs on
-# node:sqlite (built-in) and hash-wasm (pure WebAssembly), so the runtime
-# image needs nothing beyond Node itself.
+# Multi-stage build on Debian slim (glibc). sodium-native (pulled in by
+# @fastify/secure-session) ships reliable glibc prebuilds; musl prebuilds
+# on Alpine are flaky, so we stay on glibc.
 
 ARG VERSION=0.0.0
 ARG REVISION=unknown
 
-# ---- Stage 1: Backend deps (pure JS only) ----
-FROM node:24-alpine AS backend-deps
+# ---- Stage 1: Backend deps ----
+FROM node:24-slim AS backend-deps
 WORKDIR /build
 COPY server/package.json ./
 RUN npm install --omit=dev --no-audit --no-fund
 
 # ---- Stage 2: Browser vendor bundle (zxcvbn-ts) ----
-FROM node:24-alpine AS vendor
+FROM node:24-slim AS vendor
 WORKDIR /build
 COPY package.json ./
 COPY scripts ./scripts
@@ -22,7 +22,7 @@ COPY public ./public
 RUN node scripts/build-vendor.mjs
 
 # ---- Stage 3: Runtime ----
-FROM node:24-alpine
+FROM node:24-slim
 ARG VERSION
 ARG REVISION
 LABEL org.opencontainers.image.title="couplecards" \
@@ -34,8 +34,11 @@ LABEL org.opencontainers.image.title="couplecards" \
       org.opencontainers.image.version="$VERSION" \
       org.opencontainers.image.revision="$REVISION"
 
-RUN apk add --no-cache tini wget \
-  && addgroup -S app && adduser -S app -G app
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends tini wget \
+  && rm -rf /var/lib/apt/lists/* \
+  && groupadd --system app \
+  && useradd --system --gid app --home-dir /app --shell /usr/sbin/nologin app
 WORKDIR /app
 ENV NODE_ENV=production \
     PORT=3000 \
@@ -54,5 +57,5 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD wget -qO- http://127.0.0.1:3000/api/health >/dev/null 2>&1 || exit 1
 
-ENTRYPOINT ["/sbin/tini", "--"]
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["node", "server/src/index.js"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "description": "CoupleCards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

- Container crashed on startup with `ADDON_NOT_FOUND` for `sodium-native` (pulled in by `@fastify/secure-session`), because musl prebuilds are not reliably fetched by npm on Alpine.
- Switched all three build stages from `node:24-alpine` to `node:24-slim` (Debian/glibc), adapted `apk` → `apt-get`, user creation to `useradd --system`, and `tini` path from `/sbin/tini` to `/usr/bin/tini`.
- Bumped to `1.0.1` with a CHANGELOG entry.

## Test plan

- [ ] CI `build` check passes.
- [ ] After merge + tag `v1.0.1`, the Release workflow publishes `ghcr.io/qiaeru/couplecards:v1.0.1` and `:latest`.
- [ ] Pulling the new image: no more `ADDON_NOT_FOUND`, `/api/health` répond 200.
