### PR TITLE
fix: pin container UID/GID to 999 and document volume ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 _Nothing released yet._
 
+## [1.0.2] - 2026-04-23
+
+### Changed
+
+- Pinned the container runtime UID and GID to `999:999` explicitly (previously assigned automatically by `useradd --system`, which could drift across base-image updates). Existing deployments on v1.0.1 do not need to re-chown since the effective UID was already 999.
+
+### Documentation
+
+- Deployment guide now states that host directories bind-mounted to `/app/var` must be owned by UID 999, and shows the `mkdir -p ./var && sudo chown -R 999:999 ./var` bootstrap step. This prevents the `SQLITE_ERROR: unable to open database file` crash that first-time self-hosted installs hit when Docker auto-creates the bind-mount as root.
+
 ## [1.0.1] - 2026-04-23
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ LABEL org.opencontainers.image.title="couplecards" \
 RUN apt-get update \
   && apt-get install -y --no-install-recommends tini wget \
   && rm -rf /var/lib/apt/lists/* \
-  && groupadd --system app \
-  && useradd --system --gid app --home-dir /app --shell /usr/sbin/nologin app
+  && groupadd --system --gid 999 app \
+  && useradd --system --uid 999 --gid 999 --home-dir /app --shell /usr/sbin/nologin app
 WORKDIR /app
 ENV NODE_ENV=production \
     PORT=3000 \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,6 +39,15 @@ See [configuration.md](./configuration.md) for the full reference. The only mand
 
 The SQLite database lives at `/app/var/couplecards.db` inside the container and is bind-mounted to `./var/couplecards.db` on the host, relative to the Compose file you run.
 
+The container runs as a non-root user with **UID 999, GID 999**. The host directory you bind-mount to `/app/var` must be owned by that UID/GID, otherwise the server cannot open the database file and will crash at startup with `SQLITE_ERROR: unable to open database file`. Create the directory before the first `docker compose up` and `chown` it:
+
+```bash
+mkdir -p ./var
+sudo chown -R 999:999 ./var
+```
+
+Docker creates missing bind-mount directories as root by default, which is why this step is required. Named Docker volumes do not need this step.
+
 ### Manual backup
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "description": "CoupleCards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

- Pin app user to `uid=999, gid=999` in the Dockerfile (previously implicit via `useradd --system`, works today but could drift on base-image updates).
- Document in `docs/deployment.md` that host bind-mount directories for `/app/var` must be owned by UID 999, with the `mkdir -p ./var && sudo chown -R 999:999 ./var` bootstrap command.
- Bump to `1.0.2` with CHANGELOG entry.

## Why

A first-time self-hosted install (v1.0.1) crashed at startup with `SQLITE_ERROR: unable to open database file` because Docker auto-created the bind-mount directory as root while the container runs as non-root. Fix is documentation + UID pinning so the chown command is stable across upgrades.

## Test plan

- [ ] CI `build` check passes.
- [ ] After merge + tag `v1.0.2`, the Release workflow publishes `ghcr.io/qiaeru/couplecards:v1.0.2` and `:latest`.
- [ ] Existing v1.0.1 deployments do not need re-chown (UID was already 999).
- [ ] A fresh install following the new deployment guide starts without `SQLITE_ERROR`.