### PR TITLE
chore(release): cut version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+_Nothing released yet._
+
+## [1.2.0] - 2026-04-24
+
 ### Added
 
 - README: hero screenshots (desktop + mobile) and a "Try the demo" callout pointing at <https://couplecards.qiaeru.com/> with the `demo` / `demo` credentials.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/csrf-protection": "^7.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "description": "CoupleCards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

Cuts v1.2.0. Bumps `package.json`, `server/package.json`, and both lockfiles from 1.1.0 to 1.2.0. Renames the `[Unreleased]` CHANGELOG section to `[1.2.0] - 2026-04-24` and opens a fresh empty `[Unreleased]` above.

No code changes in this PR. All 1.2.0 content was merged via #10.

Headline changes shipping in 1.2.0:
- New pink heart brand identity (`#ec5a9e`): logo, `favicon.ico`, `apple-touch-icon.png`, and wordmark lockups on every title.
- Unified flat-pink title typography with tighter tracking.
- Brand colour centralised on `--accent` in `themes.css`; zero hardcoded pink rgbas remain.
- Bottom-nav tap-highlight flash fixed; icons enlarged (22 to 26 px) and icon-label gap loosened (4 to 6 px).
- Desktop home pile spacing widened (gap 14 to 40 px).
- README gains a "Try the demo" callout and hero screenshots.

Full notes under `## [1.2.0] - 2026-04-24` in `CHANGELOG.md`.

## Test plan

- [ ] CI `build` passes on the branch.
