### PR TITLE
chore: add FUNDING.yml to enable the GitHub Sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: qiaeru
+ko_fi: qiaeru


### PR DESCRIPTION
## Summary

Adds `.github/FUNDING.yml` with two entries:

- `github: qiaeru` — GitHub Sponsors
- `ko_fi: qiaeru` — Ko-fi (already active at https://ko-fi.com/qiaeru)

GitHub renders a **Sponsor** button at the top of the repo and in the sidebar of every Issue and PR. Both destinations appear in the menu; visitors pick whichever works for them.

## Test plan

- [ ] CI `build` passes.
- [ ] After merge: the **Sponsor** button appears on the repo homepage (<https://github.com/qiaeru/couplecards>) and links to both GitHub Sponsors and Ko-fi.
