### PR TITLE
docs(readme): add release, docker image and stars badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # CoupleCards
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![Release](https://img.shields.io/github/v/release/qiaeru/couplecards)](https://github.com/qiaeru/couplecards/releases)
+[![Docker image](https://img.shields.io/badge/ghcr.io-qiaeru%2Fcouplecards-blue)](https://github.com/qiaeru/couplecards/pkgs/container/couplecards)
+[![GitHub stars](https://img.shields.io/github/stars/qiaeru/couplecards?style=social)](https://github.com/qiaeru/couplecards/stargazers)
 
 A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.
 


### PR DESCRIPTION
## Summary

Add three badges next to the existing MIT licence badge in the README header:

- Latest GitHub release
- GHCR Docker image link
- GitHub stars count

## Rationale

The project is about to be submitted to selfh.st and posted in the r/selfhosted new project megathread. Visible badges at the top give readers an instant "active project" signal (current release, published image, community traction) before they scroll to the screenshots and Quick Start.

No functional change, README-only.
