### PR TITLE
fix(a11y): headings, labels, skip link, focus, tabs and modal hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Accessibility: add a focus trap, `Escape` to close, backdrop click to close, and focus return to the opener on the Sync / Import deck-sync modal. It previously lacked all four, unlike the shared confirmation modal.
 - Accessibility: hide the decorative emoji on empty-state screens (Admin cards, Bans, History) from assistive tech. Screen readers stopped announcing "playing card", "herb" or "heart with ribbon" before the real title and hint.
 - Accessibility: expose the home screen "Almost empty" hint to screen readers. The pile button uses `aria-label`, which replaced its inner text for assistive tech, so the visible low-pile warning was ignored. It is now linked via `aria-describedby` only while the hint is actually shown.
+- Accessibility: link the sign-in and change-password inputs to their error region via `aria-describedby`, and toggle `aria-invalid` on each field while the form holds an error. The password-change "New password" field also links to the strength meter so screen readers reach the live hints when the field is focused.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Accessibility: replace the first tab stop of the SPA shell with a real "Skip to main content" link. It previously pointed at `#/home` with the label "Back", which was misleading for keyboard users expecting the standard skip-link behaviour. It now targets `<main id="main-content">` (marked `tabindex="-1"` so it can receive focus) and uses a dedicated `common.skipToContent` i18n key in both locales.
 - Accessibility: move focus to `<main id="main-content">` after every SPA route change. Keyboard and screen-reader users now hear the new view's contents instead of staying stranded on the last clicked link.
 - Accessibility: tag the revealed card's title and description with the effective `lang` attribute. When a card has no translation in the active UI locale and falls back to English, screen readers now switch to the English voice instead of mispronouncing the text with the UI voice.
+- Accessibility: make the admin tablist follow the WAI-ARIA APG tabs pattern. The active tab carries `tabindex="0"` and every other tab `tabindex="-1"`, so `Tab` moves from the tablist straight into the visible panel. `ArrowLeft` / `ArrowRight`, `Home` and `End` now cycle between tabs and move focus to the newly selected one.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Accessibility: expose the home screen "Almost empty" hint to screen readers. The pile button uses `aria-label`, which replaced its inner text for assistive tech, so the visible low-pile warning was ignored. It is now linked via `aria-describedby` only while the hint is actually shown.
 - Accessibility: link the sign-in and change-password inputs to their error region via `aria-describedby`, and toggle `aria-invalid` on each field while the form holds an error. The password-change "New password" field also links to the strength meter so screen readers reach the live hints when the field is focused.
 - Accessibility: mark the password strength label as an `aria-live="polite"` region and only mutate its text when the tier actually changes. Screen readers now hear the new strength level (Weak, Fair, Good, Strong) once when it shifts, instead of staying silent or spamming every keystroke.
+- Accessibility: add a focus trap, `Escape` to close, backdrop click to close, and focus return to the opener on the admin Create / Edit card modal. This was the remaining bespoke modal that still drove `#modal` directly without the a11y plumbing now shared by the confirmation and deck-sync dialogs.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Accessibility: make the admin tablist follow the WAI-ARIA APG tabs pattern. The active tab carries `tabindex="0"` and every other tab `tabindex="-1"`, so `Tab` moves from the tablist straight into the visible panel. `ArrowLeft` / `ArrowRight`, `Home` and `End` now cycle between tabs and move focus to the newly selected one.
 - Accessibility: add a focus trap, `Escape` to close, backdrop click to close, and focus return to the opener on the Sync / Import deck-sync modal. It previously lacked all four, unlike the shared confirmation modal.
 - Accessibility: hide the decorative emoji on empty-state screens (Admin cards, Bans, History) from assistive tech. Screen readers stopped announcing "playing card", "herb" or "heart with ribbon" before the real title and hint.
+- Accessibility: expose the home screen "Almost empty" hint to screen readers. The pile button uses `aria-label`, which replaced its inner text for assistive tech, so the visible low-pile warning was ignored. It is now linked via `aria-describedby` only while the hint is actually shown.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Accessibility: tag the revealed card's title and description with the effective `lang` attribute. When a card has no translation in the active UI locale and falls back to English, screen readers now switch to the English voice instead of mispronouncing the text with the UI voice.
 - Accessibility: make the admin tablist follow the WAI-ARIA APG tabs pattern. The active tab carries `tabindex="0"` and every other tab `tabindex="-1"`, so `Tab` moves from the tablist straight into the visible panel. `ArrowLeft` / `ArrowRight`, `Home` and `End` now cycle between tabs and move focus to the newly selected one.
 - Accessibility: add a focus trap, `Escape` to close, backdrop click to close, and focus return to the opener on the Sync / Import deck-sync modal. It previously lacked all four, unlike the shared confirmation modal.
+- Accessibility: hide the decorative emoji on empty-state screens (Admin cards, Bans, History) from assistive tech. Screen readers stopped announcing "playing card", "herb" or "heart with ribbon" before the real title and hint.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Accessibility: demote the CoupleCards wordmark on `login.html` from `<h1>` to `<div>`. Each login stage (Sign in, Change password) keeps its own `<h1>`, so the document hierarchy now has a single top-level heading per view instead of two.
+
 ### Security
 
 - Raise the Argon2id iteration count from `t=2` to `t=3` on password hashing. Still uses the same 19 MiB memory cost. Adds roughly 15 ms to each login and password change; existing stored hashes keep verifying since the PHC string embeds its own parameters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Accessibility: demote the CoupleCards wordmark on `login.html` from `<h1>` to `<div>`. Each login stage (Sign in, Change password) keeps its own `<h1>`, so the document hierarchy now has a single top-level heading per view instead of two.
 - Accessibility: associate the Settings switches (Sound effects, Vibrations) with their visible label via `aria-labelledby`. Screen readers now announce the checkbox name instead of an unlabeled toggle.
 - Accessibility: replace the first tab stop of the SPA shell with a real "Skip to main content" link. It previously pointed at `#/home` with the label "Back", which was misleading for keyboard users expecting the standard skip-link behaviour. It now targets `<main id="main-content">` (marked `tabindex="-1"` so it can receive focus) and uses a dedicated `common.skipToContent` i18n key in both locales.
+- Accessibility: move focus to `<main id="main-content">` after every SPA route change. Keyboard and screen-reader users now hear the new view's contents instead of staying stranded on the last clicked link.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Accessibility: associate the Settings switches (Sound effects, Vibrations) with their visible label via `aria-labelledby`. Screen readers now announce the checkbox name instead of an unlabeled toggle.
 - Accessibility: replace the first tab stop of the SPA shell with a real "Skip to main content" link. It previously pointed at `#/home` with the label "Back", which was misleading for keyboard users expecting the standard skip-link behaviour. It now targets `<main id="main-content">` (marked `tabindex="-1"` so it can receive focus) and uses a dedicated `common.skipToContent` i18n key in both locales.
 - Accessibility: move focus to `<main id="main-content">` after every SPA route change. Keyboard and screen-reader users now hear the new view's contents instead of staying stranded on the last clicked link.
+- Accessibility: tag the revealed card's title and description with the effective `lang` attribute. When a card has no translation in the active UI locale and falls back to English, screen readers now switch to the English voice instead of mispronouncing the text with the UI voice.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Accessibility: hide the decorative emoji on empty-state screens (Admin cards, Bans, History) from assistive tech. Screen readers stopped announcing "playing card", "herb" or "heart with ribbon" before the real title and hint.
 - Accessibility: expose the home screen "Almost empty" hint to screen readers. The pile button uses `aria-label`, which replaced its inner text for assistive tech, so the visible low-pile warning was ignored. It is now linked via `aria-describedby` only while the hint is actually shown.
 - Accessibility: link the sign-in and change-password inputs to their error region via `aria-describedby`, and toggle `aria-invalid` on each field while the form holds an error. The password-change "New password" field also links to the strength meter so screen readers reach the live hints when the field is focused.
+- Accessibility: mark the password strength label as an `aria-live="polite"` region and only mutate its text when the tier actually changes. Screen readers now hear the new strength level (Weak, Fair, Good, Strong) once when it shifts, instead of staying silent or spamming every keystroke.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Accessibility: demote the CoupleCards wordmark on `login.html` from `<h1>` to `<div>`. Each login stage (Sign in, Change password) keeps its own `<h1>`, so the document hierarchy now has a single top-level heading per view instead of two.
+- Accessibility: associate the Settings switches (Sound effects, Vibrations) with their visible label via `aria-labelledby`. Screen readers now announce the checkbox name instead of an unlabeled toggle.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Accessibility: move focus to `<main id="main-content">` after every SPA route change. Keyboard and screen-reader users now hear the new view's contents instead of staying stranded on the last clicked link.
 - Accessibility: tag the revealed card's title and description with the effective `lang` attribute. When a card has no translation in the active UI locale and falls back to English, screen readers now switch to the English voice instead of mispronouncing the text with the UI voice.
 - Accessibility: make the admin tablist follow the WAI-ARIA APG tabs pattern. The active tab carries `tabindex="0"` and every other tab `tabindex="-1"`, so `Tab` moves from the tablist straight into the visible panel. `ArrowLeft` / `ArrowRight`, `Home` and `End` now cycle between tabs and move focus to the newly selected one.
+- Accessibility: add a focus trap, `Escape` to close, backdrop click to close, and focus return to the opener on the Sync / Import deck-sync modal. It previously lacked all four, unlike the shared confirmation modal.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Accessibility: demote the CoupleCards wordmark on `login.html` from `<h1>` to `<div>`. Each login stage (Sign in, Change password) keeps its own `<h1>`, so the document hierarchy now has a single top-level heading per view instead of two.
 - Accessibility: associate the Settings switches (Sound effects, Vibrations) with their visible label via `aria-labelledby`. Screen readers now announce the checkbox name instead of an unlabeled toggle.
+- Accessibility: replace the first tab stop of the SPA shell with a real "Skip to main content" link. It previously pointed at `#/home` with the label "Back", which was misleading for keyboard users expecting the standard skip-link behaviour. It now targets `<main id="main-content">` (marked `tabindex="-1"` so it can receive focus) and uses a dedicated `common.skipToContent` i18n key in both locales.
 
 ### Security
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -14,7 +14,7 @@ Audience: maintainers and contributors. This page summarises what the app implem
 
 ### Global
 
-The `<html lang>` attribute is updated whenever the i18n locale changes. Every interactive control is focusable and exposes a visible ring through `:focus-visible`. A skip link sits at the top of the SPA shell. Toasts and card announcements live in `role="status"` regions. `prefers-reduced-motion` disables decorative animations, and `prefers-reduced-transparency` removes backdrop blurs.
+The `<html lang>` attribute is updated whenever the i18n locale changes. Every interactive control is focusable and exposes a visible ring through `:focus-visible`. The first tab stop on the SPA shell is a "Skip to main content" link that moves focus to `<main id="main-content" tabindex="-1">`. Toasts and card announcements live in `role="status"` regions. `prefers-reduced-motion` disables decorative animations, and `prefers-reduced-transparency` removes backdrop blurs.
 
 ### Forms
 

--- a/public/admin.html
+++ b/public/admin.html
@@ -25,9 +25,9 @@
     </header>
 
     <nav class="admin-tabs" role="tablist">
-      <button type="button" id="admin-tab-users" class="admin-tab" role="tab" aria-selected="true"  data-i18n="admin.tabs.users">Users</button>
-      <button type="button" id="admin-tab-cards" class="admin-tab" role="tab" aria-selected="false" data-i18n="admin.tabs.cards">Cards</button>
-      <button type="button" id="admin-tab-settings" class="admin-tab admin-tab-right" role="tab" aria-selected="false" data-i18n="admin.tabs.settings">Settings</button>
+      <button type="button" id="admin-tab-users" class="admin-tab" role="tab" aria-selected="true"  tabindex="0"  data-i18n="admin.tabs.users">Users</button>
+      <button type="button" id="admin-tab-cards" class="admin-tab" role="tab" aria-selected="false" tabindex="-1" data-i18n="admin.tabs.cards">Cards</button>
+      <button type="button" id="admin-tab-settings" class="admin-tab admin-tab-right" role="tab" aria-selected="false" tabindex="-1" data-i18n="admin.tabs.settings">Settings</button>
     </nav>
 
     <section id="admin-panel-users" class="admin-panel" role="tabpanel" aria-labelledby="admin-tab-users">

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
   <meta name="apple-mobile-web-app-title" content="CoupleCards">
 </head>
 <body>
-  <a href="#/home" class="skip-link" data-i18n="common.back">Back</a>
+  <a href="#main-content" class="skip-link" data-i18n="common.skipToContent">Skip to main content</a>
   <div id="screen-announce" class="sr-only" role="status" aria-live="polite"></div>
 
   <div id="boot-skeleton" class="boot-skeleton">
@@ -39,7 +39,7 @@
 
   <div id="app" hidden>
     <div id="demo-banner" class="demo-banner" role="status" aria-live="polite" hidden></div>
-    <main id="main-content">
+    <main id="main-content" tabindex="-1">
       <div id="view" class="screen"></div>
     </main>
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -7,17 +7,39 @@ import { initScrollToTop } from './ui/scroll-to-top.js';
 
 const TABS = ['users', 'cards', 'settings'];
 
-function activateTab(name) {
+// Tabs follow the WAI-ARIA APG pattern: the active tab carries tabindex="0",
+// every other tab carries tabindex="-1" so Tab moves from the tablist straight
+// into the visible panel rather than cycling across the three buttons.
+function activateTab(name, { focus = false } = {}) {
   for (const tab of TABS) {
     const panel = document.getElementById(`admin-panel-${tab}`);
     const btn = document.getElementById(`admin-tab-${tab}`);
-    if (panel) panel.hidden = tab !== name;
+    const isActive = tab === name;
+    if (panel) panel.hidden = !isActive;
     if (btn) {
-      btn.classList.toggle('active', tab === name);
-      btn.setAttribute('aria-selected', tab === name ? 'true' : 'false');
+      btn.classList.toggle('active', isActive);
+      btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      btn.setAttribute('tabindex', isActive ? '0' : '-1');
+      if (isActive && focus) btn.focus();
     }
   }
   sessionStorage.setItem('couplecards:admin-tab', name);
+}
+
+function onTabKey(event) {
+  const currentName = event.currentTarget.id.replace(/^admin-tab-/, '');
+  const currentIndex = TABS.indexOf(currentName);
+  if (currentIndex < 0) return;
+  let nextIndex = null;
+  switch (event.key) {
+    case 'ArrowLeft':  nextIndex = (currentIndex - 1 + TABS.length) % TABS.length; break;
+    case 'ArrowRight': nextIndex = (currentIndex + 1) % TABS.length; break;
+    case 'Home':       nextIndex = 0; break;
+    case 'End':        nextIndex = TABS.length - 1; break;
+    default: return;
+  }
+  event.preventDefault();
+  activateTab(TABS[nextIndex], { focus: true });
 }
 
 async function init() {
@@ -30,7 +52,10 @@ async function init() {
   applyI18n(document);
 
   for (const tab of TABS) {
-    document.getElementById(`admin-tab-${tab}`)?.addEventListener('click', () => activateTab(tab));
+    const btn = document.getElementById(`admin-tab-${tab}`);
+    if (!btn) continue;
+    btn.addEventListener('click', () => activateTab(tab));
+    btn.addEventListener('keydown', onTabKey);
   }
 
   const initialTab = sessionStorage.getItem('couplecards:admin-tab') || 'users';

--- a/public/js/core/router.js
+++ b/public/js/core/router.js
@@ -68,6 +68,11 @@ export async function render() {
   }
   document.dispatchEvent(new CustomEvent('route:mounted', { detail: { route: segment } }));
   window.scrollTo(0, 0);
+
+  // Reset focus to the new view so screen readers pick up the change.
+  // <main id="main-content"> carries tabindex="-1" so it can receive focus
+  // without entering the normal tab order.
+  document.getElementById('main-content')?.focus({ preventScroll: true });
 }
 
 export function startRouter() {

--- a/public/js/core/sync.js
+++ b/public/js/core/sync.js
@@ -116,18 +116,24 @@ export function getCardById(id) {
 
 // Picks a translation for `locale`, falls back to English then any available.
 // Also handles the legacy `{title, description}` shape so a stale /api/cards
-// cache from a previous version never leaves the lists blank.
+// cache from a previous version never leaves the lists blank. The returned
+// `locale` reflects what the caller actually got, which lets views tag the
+// rendered text with `lang` so screen readers switch voice on fallback.
 export function getCardText(card, locale = getLocale()) {
-  const placeholder = { title: '', description: '' };
+  const placeholder = { title: '', description: '', locale };
   if (!card) return placeholder;
   if (card.translations) {
-    const t = card.translations[locale]
-      || card.translations[FALLBACK_LOCALE]
-      || Object.values(card.translations).find(Boolean);
-    if (t) return t;
+    if (card.translations[locale]) {
+      return { ...card.translations[locale], locale };
+    }
+    if (card.translations[FALLBACK_LOCALE]) {
+      return { ...card.translations[FALLBACK_LOCALE], locale: FALLBACK_LOCALE };
+    }
+    const [effectiveLocale, t] = Object.entries(card.translations).find(([, v]) => v) || [];
+    if (t) return { ...t, locale: effectiveLocale };
   }
   if (card.title || card.description) {
-    return { title: card.title ?? '', description: card.description ?? '' };
+    return { title: card.title ?? '', description: card.description ?? '', locale };
   }
   return placeholder;
 }

--- a/public/js/features/admin/cards.js
+++ b/public/js/features/admin/cards.js
@@ -116,8 +116,10 @@ function openCardDialog({ card = null } = {}) {
   const bodyEl = document.getElementById('modal-body');
   const confirmBtn = document.getElementById('modal-confirm');
   const cancelBtn = document.getElementById('modal-cancel');
+  const backdrop = host?.querySelector('[data-modal-close]');
   if (!host) return;
 
+  const previouslyFocused = document.activeElement;
   const isEdit = !!card;
   titleEl.textContent = isEdit ? t('admin.cards.edit') : t('admin.cards.create');
   bodyEl.innerHTML = `
@@ -151,12 +153,36 @@ function openCardDialog({ card = null } = {}) {
   cancelBtn.textContent = t('common.cancel');
   host.hidden = false;
 
+  const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  const getFocusables = () => Array.from(host.querySelectorAll(FOCUSABLE))
+    .filter((el) => !el.hidden && el.offsetParent !== null);
+
   const close = () => {
     host.hidden = true;
     confirmBtn.removeEventListener('click', onConfirm);
     cancelBtn.removeEventListener('click', onCancel);
+    backdrop?.removeEventListener('click', onCancel);
+    document.removeEventListener('keydown', onKey);
+    if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+      try { previouslyFocused.focus(); } catch {}
+    }
   };
   const onCancel = () => close();
+  const onKey = (event) => {
+    if (event.key === 'Escape') { event.preventDefault(); close(); return; }
+    if (event.key !== 'Tab') return;
+    const items = getFocusables();
+    if (items.length === 0) return;
+    const first = items[0];
+    const last = items[items.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
   const onConfirm = async () => {
     const form = document.getElementById('card-form');
     const err = document.getElementById('card-error');
@@ -190,6 +216,8 @@ function openCardDialog({ card = null } = {}) {
   };
   confirmBtn.addEventListener('click', onConfirm);
   cancelBtn.addEventListener('click', onCancel);
+  backdrop?.addEventListener('click', onCancel);
+  document.addEventListener('keydown', onKey);
   setTimeout(() => (isEdit
     ? document.querySelector('[name="title-' + getLocale() + '"]')
     : document.getElementById('card-id'))?.focus(), 50);

--- a/public/js/features/admin/cards.js
+++ b/public/js/features/admin/cards.js
@@ -54,7 +54,7 @@ function renderCardsList(cards) {
   host.innerHTML = '';
   if (cards.length === 0) {
     host.innerHTML = `<div class="empty">
-      <div class="empty-icon">🃏</div>
+      <div class="empty-icon" aria-hidden="true">🃏</div>
       <div class="empty-title">${escapeHtml(t('admin.cards.empty.title'))}</div>
       <div class="empty-hint">${escapeHtml(t('admin.cards.empty.hint'))}</div>
     </div>`;

--- a/public/js/features/admin/deck-sync.js
+++ b/public/js/features/admin/deck-sync.js
@@ -102,7 +102,10 @@ function withModal({ title, bodyHtml, confirmLabel, cancelLabel, danger, onConfi
   const bodyEl = document.getElementById('modal-body');
   const confirmBtn = document.getElementById('modal-confirm');
   const cancelBtn = document.getElementById('modal-cancel');
+  const backdrop = host?.querySelector('[data-modal-close]');
   if (!host) return { close: () => {} };
+
+  const previouslyFocused = document.activeElement;
 
   titleEl.textContent = title;
   bodyEl.innerHTML = bodyHtml;
@@ -114,19 +117,56 @@ function withModal({ title, bodyHtml, confirmLabel, cancelLabel, danger, onConfi
   cancelBtn.textContent = cancelLabel;
   host.hidden = false;
 
+  // Every focusable control currently inside the modal (body inputs +
+  // confirm/cancel). Queried on each Tab so dynamic bodies (preview summary,
+  // mode switches) stay in the trap.
+  const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  const getFocusables = () => Array.from(host.querySelectorAll(FOCUSABLE))
+    .filter((el) => !el.hidden && el.offsetParent !== null);
+
   const close = () => {
     host.hidden = true;
     confirmBtn.removeEventListener('click', handler);
     cancelBtn.removeEventListener('click', cancel);
+    backdrop?.removeEventListener('click', cancel);
+    document.removeEventListener('keydown', onKey);
+    if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+      try { previouslyFocused.focus(); } catch {}
+    }
   };
   const cancel = () => close();
   const handler = async () => {
     try { await onConfirm({ close, confirmBtn }); }
     catch {}
   };
+  const onKey = (event) => {
+    if (event.key === 'Escape') { event.preventDefault(); cancel(); return; }
+    if (event.key !== 'Tab') return;
+    const items = getFocusables();
+    if (items.length === 0) return;
+    const first = items[0];
+    const last = items[items.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
   confirmBtn.addEventListener('click', handler);
   cancelBtn.addEventListener('click', cancel);
+  backdrop?.addEventListener('click', cancel);
+  document.addEventListener('keydown', onKey);
   onBodyReady?.({ close });
+
+  // Defer initial focus so the body has rendered its first focusable control.
+  setTimeout(() => {
+    const [first] = getFocusables();
+    (first || confirmBtn).focus();
+  }, 50);
+
   return { close };
 }
 

--- a/public/js/features/bans/bans.js
+++ b/public/js/features/bans/bans.js
@@ -22,7 +22,7 @@ function render() {
   host.innerHTML = '';
   if (banned.length === 0) {
     host.innerHTML = `<div class="empty">
-      <div class="empty-icon">🌿</div>
+      <div class="empty-icon" aria-hidden="true">🌿</div>
       <div class="empty-title">${escapeHtml(t('bans.empty.title'))}</div>
       <div class="empty-hint">${escapeHtml(t('bans.empty.hint'))}</div>
     </div>`;

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -458,9 +458,15 @@ function announceCard(card) {
 // Re-called on reveal and on locale change so the visible card follows
 // the active language.
 function applyCardText(card) {
-  const { title, description } = getCardText(card);
-  $('card-title').textContent = title;
-  $('card-description').textContent = description;
+  const { title, description, locale } = getCardText(card);
+  const titleEl = $('card-title');
+  const descEl = $('card-description');
+  titleEl.textContent = title;
+  descEl.textContent = description;
+  // Tag with the effective locale so screen readers switch voice when the
+  // card falls back to English because the requested locale is missing.
+  titleEl.setAttribute('lang', locale);
+  descEl.setAttribute('lang', locale);
 }
 
 export async function startDraw(pile) {

--- a/public/js/features/history/history.js
+++ b/public/js/features/history/history.js
@@ -52,7 +52,7 @@ function render() {
   host.innerHTML = '';
   if (history.length === 0) {
     host.innerHTML = `<div class="empty">
-      <div class="empty-icon">💝</div>
+      <div class="empty-icon" aria-hidden="true">💝</div>
       <div class="empty-title">${escapeHtml(t('history.empty.title'))}</div>
       <div class="empty-hint">${escapeHtml(t('history.empty.hint'))}</div>
     </div>`;

--- a/public/js/features/home/home.js
+++ b/public/js/features/home/home.js
@@ -31,6 +31,12 @@ export function refreshHomeCounts() {
       btn.classList.toggle('empty', empty);
       btn.classList.toggle('low', low);
       btn.disabled = empty;
+      // The pile button uses aria-label, which replaces its inner text for
+      // screen readers, so the visible "Almost empty" hint would otherwise
+      // be invisible to assistive tech. Link it via aria-describedby only
+      // when it is actually shown.
+      if (low) btn.setAttribute('aria-describedby', `low-${pile}`);
+      else btn.removeAttribute('aria-describedby');
     }
     const hint = document.getElementById(`low-${pile}`);
     if (hint) hint.hidden = !(remaining[pile] > 0 && remaining[pile] <= 3);

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -15,9 +15,21 @@ function showStep(name) {
   }
 }
 
+const ERROR_FIELDS = {
+  login:  ['login-username', 'login-password'],
+  change: ['change-current', 'change-new', 'change-confirm'],
+};
+
 function showError(scope, code, extra = {}) {
   const el = document.getElementById(`${scope}-error`);
   if (!el) return;
+  const invalid = !!code;
+  for (const id of ERROR_FIELDS[scope] || []) {
+    const input = document.getElementById(id);
+    if (!input) continue;
+    if (invalid) input.setAttribute('aria-invalid', 'true');
+    else input.removeAttribute('aria-invalid');
+  }
   if (!code) { el.textContent = ''; return; }
   const key = code.startsWith('login.errors.') ? code : `errors.${code}`;
   const fallback = t('errors.generic');

--- a/public/js/ui/password-strength.js
+++ b/public/js/ui/password-strength.js
@@ -56,7 +56,7 @@ export function bindPasswordStrength({ input, host, userInputs = [], minScore = 
       <div class="pw-strength-bar" role="presentation">
         <div class="pw-strength-fill" data-fill></div>
       </div>
-      <div class="pw-strength-label" data-label></div>
+      <div class="pw-strength-label" data-label aria-live="polite" aria-atomic="true"></div>
       <ul class="pw-strength-rules" data-rules>
         <li data-rule="minLength">${t('changePassword.policy.minLength', { min: RULES.minLength })}</li>
         <li data-rule="upper">${t('changePassword.policy.upper')}</li>
@@ -73,6 +73,11 @@ export function bindPasswordStrength({ input, host, userInputs = [], minScore = 
   const label = host.querySelector('[data-label]');
   const rules = host.querySelectorAll('[data-rule]');
 
+  // Track the last announced label so we only mutate textContent when the
+  // strength tier actually changed. Re-setting the same string would still
+  // trigger the live region to re-announce on every keystroke.
+  let lastLabel = '';
+
   const update = async () => {
     const value = input.value;
     const hard = evaluateHardRules(value, userInputs[0] || '');
@@ -85,7 +90,11 @@ export function bindPasswordStrength({ input, host, userInputs = [], minScore = 
     const pct = (score / 4) * 100;
     fill.style.width = `${pct}%`;
     fill.dataset.score = String(score);
-    label.textContent = value ? t(`changePassword.strength.${score}`) : '';
+    const nextLabel = value ? t(`changePassword.strength.${score}`) : '';
+    if (nextLabel !== lastLabel) {
+      label.textContent = nextLabel;
+      lastLabel = nextLabel;
+    }
     const allHard = Object.values(hard).every(Boolean);
     input.setCustomValidity(allHard && score >= minScore ? '' : 'weak');
   };

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -10,6 +10,7 @@
   "common.edit": "Edit",
   "common.ok": "OK",
   "common.back": "Back",
+  "common.skipToContent": "Skip to main content",
   "common.scrollTop": "Back to top",
   "common.dateAtTime": "{{date}} at {{time}}",
   "common.copy": "Copy",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -10,6 +10,7 @@
   "common.edit": "Modifier",
   "common.ok": "Valider",
   "common.back": "Retour",
+  "common.skipToContent": "Aller au contenu principal",
   "common.scrollTop": "Revenir en haut",
   "common.dateAtTime": "{{date}} à {{time}}",
   "common.copy": "Copier",

--- a/public/login.html
+++ b/public/login.html
@@ -29,12 +29,15 @@
           <span data-i18n="login.username">Username</span>
           <input type="text" id="login-username" name="username"
                  autocomplete="username" autocapitalize="off" spellcheck="false"
+                 aria-describedby="login-error"
                  required minlength="3" maxlength="32" pattern="[a-z0-9._\-]+">
         </label>
         <label class="field">
           <span data-i18n="login.password">Password</span>
           <input type="password" id="login-password" name="password"
-                 autocomplete="current-password" required>
+                 autocomplete="current-password"
+                 aria-describedby="login-error"
+                 required>
         </label>
         <div class="auth-error" id="login-error" role="alert" aria-live="polite"></div>
         <button type="submit" class="btn btn-primary" data-i18n="login.submit">Sign in</button>
@@ -47,16 +50,21 @@
       <form id="change-form" class="auth-form" novalidate>
         <label class="field">
           <span data-i18n="changePassword.current">Current password</span>
-          <input type="password" id="change-current" autocomplete="current-password" required>
+          <input type="password" id="change-current" autocomplete="current-password"
+                 aria-describedby="change-error" required>
         </label>
         <label class="field">
           <span data-i18n="changePassword.new">New password</span>
-          <input type="password" id="change-new" autocomplete="new-password" required minlength="12">
+          <input type="password" id="change-new" autocomplete="new-password"
+                 aria-describedby="change-strength change-error"
+                 required minlength="12">
         </label>
         <div id="change-strength"></div>
         <label class="field">
           <span data-i18n="changePassword.confirm">Confirm new password</span>
-          <input type="password" id="change-confirm" autocomplete="new-password" required minlength="12">
+          <input type="password" id="change-confirm" autocomplete="new-password"
+                 aria-describedby="change-error"
+                 required minlength="12">
         </label>
         <div class="auth-error" id="change-error" role="alert" aria-live="polite"></div>
         <button type="submit" class="btn btn-primary" data-i18n="changePassword.submit">Update my password</button>

--- a/public/login.html
+++ b/public/login.html
@@ -17,10 +17,10 @@
 </head>
 <body>
   <main class="auth-shell">
-    <h1 class="brand-title">
+    <div class="brand-title">
       <img class="title-icon" src="/icons/icon.svg" alt="" aria-hidden="true" draggable="false">
       <span data-i18n="app.name">CoupleCards</span>
-    </h1>
+    </div>
     <section class="auth-card" id="step-login" hidden>
       <h1 class="auth-title" data-i18n="login.title">Sign in</h1>
       <p class="auth-subtitle" data-i18n="login.subtitle"></p>

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v11';
+const VERSION = 'couplecards-v12';
 const SHELL = [
   '/',
   '/index.html',

--- a/public/views/settings.html
+++ b/public/views/settings.html
@@ -16,16 +16,16 @@
     <select id="setting-language" class="setting-select"></select>
   </div>
   <div class="setting-row">
-    <span data-i18n="settings.sounds">Sound effects</span>
+    <span id="setting-sounds-label" data-i18n="settings.sounds">Sound effects</span>
     <label class="switch">
-      <input type="checkbox" id="setting-sounds">
+      <input type="checkbox" id="setting-sounds" aria-labelledby="setting-sounds-label">
       <span class="slider"></span>
     </label>
   </div>
   <div class="setting-row">
-    <span data-i18n="settings.vibrations">Vibrations</span>
+    <span id="setting-vibrations-label" data-i18n="settings.vibrations">Vibrations</span>
     <label class="switch">
-      <input type="checkbox" id="setting-vibrations">
+      <input type="checkbox" id="setting-vibrations" aria-labelledby="setting-vibrations-label">
       <span class="slider"></span>
     </label>
   </div>


### PR DESCRIPTION
## Summary

Twelve small accessibility fixes surfaced by three audit passes, bundled because each stands alone but all come from the same review effort. Reviewable (and revertable) commit by commit.

### Structure and labelling
1. `demote login brand wordmark from h1 to div` — one `<h1>` per login stage.
2. `label settings switches via aria-labelledby` — Sound effects and Vibrations toggles get an accessible name.
3. `replace misleading back link with real skip-to-main` — the first tab stop jumps over the chrome.

### Focus management
4. `move focus to main content after SPA navigation` — screen-reader users hear the new view.
5. `tag card text with its effective lang on fallback` — a card rendered in English under a French UI is spoken with the English voice.
6. `apply the APG tabs pattern to the admin tablist` — roving `tabindex` + arrow keys + Home / End.
7. `add focus trap and Escape to deck-sync modal` — Sync and Import dialogs match the shared confirm modal.

### Dynamic state announcement
8. `hide decorative empty-state emoji from screen readers` — no more "playing card" / "herb" before the real title.
9. `announce the low-pile hint on the home screen` — "Almost empty" is now linked via `aria-describedby` while active.
10. `wire login form inputs to errors and strength hints` — `aria-describedby` + toggled `aria-invalid`.
11. `announce password strength tier changes via aria-live` — one polite announcement per tier crossing.
12. `add focus trap and Escape to admin card modal` — the last bespoke modal matches the shared pattern.

## Expected behaviors

- **Login**: one top-level heading per stage. Each input is tied to its error region; `aria-invalid` is set while a form error is shown. The "New password" field reads the strength meter as a description.
- **Settings**: toggling Sound effects or Vibrations announces the control name.
- **SPA shell**: Tab from the address bar reveals "Skip to main content" / "Aller au contenu principal"; activating it focuses `<main>`. Every subsequent navigation lands focus on `<main>`.
- **Home**: when a pile has 3 or fewer cards left, screen readers hear "Almost empty" / "Presque vide" appended to the pile button.
- **Draw**: a card whose active locale has no translation is rendered with `lang="en"` on title and description.
- **Admin tablist**: Tab enters the active tab, the next Tab enters the panel. `ArrowLeft` / `ArrowRight` cycle between tabs (wrap around), `Home` and `End` jump to the first / last.
- **Admin modals (deck sync, create/edit card) + user confirm modals**: Tab stays inside the modal, Escape closes, backdrop click closes, focus returns to the opener.
- **Password strength**: "Weak / Fair / Good / Strong" is announced once when the tier shifts, silent within the same tier.
- **Empty-state screens** (admin cards, bans, history): the decorative emoji is ignored by screen readers.

## Notes

- Service worker cache version bumped `v11` → `v12` so clients pick up the updated shell, admin template, locales, and partials.
- `docs/accessibility.md` updated to describe the new skip-link behaviour. The rest of the page was already accurate.
- No API, routing, or config change.
