### PR TITLE
docs(a11y): sync accessibility doc and tidy [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-### Documentation
-
-- Move the README screenshots from the repository root to `docs/assets/` and render them side by side inside a two-column Markdown table with short captions. The table layout caps each image at half the container width on GitHub without resorting to inline HTML.
-
 ### Fixed
 
 - Accessibility: demote the CoupleCards wordmark on `login.html` from `<h1>` to `<div>`. Each login stage (Sign in, Change password) keeps its own `<h1>`, so the document hierarchy now has a single top-level heading per view instead of two.
@@ -18,12 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Accessibility: move focus to `<main id="main-content">` after every SPA route change. Keyboard and screen-reader users now hear the new view's contents instead of staying stranded on the last clicked link.
 - Accessibility: tag the revealed card's title and description with the effective `lang` attribute. When a card has no translation in the active UI locale and falls back to English, screen readers now switch to the English voice instead of mispronouncing the text with the UI voice.
 - Accessibility: make the admin tablist follow the WAI-ARIA APG tabs pattern. The active tab carries `tabindex="0"` and every other tab `tabindex="-1"`, so `Tab` moves from the tablist straight into the visible panel. `ArrowLeft` / `ArrowRight`, `Home` and `End` now cycle between tabs and move focus to the newly selected one.
-- Accessibility: add a focus trap, `Escape` to close, backdrop click to close, and focus return to the opener on the Sync / Import deck-sync modal. It previously lacked all four, unlike the shared confirmation modal.
+- Accessibility: apply the shared modal a11y pattern (focus trap, `Escape`, backdrop click, focus return to opener) to the Sync / Import deck-sync dialog and to the admin Create / Edit card dialog, bringing them in line with the shared confirmation modal.
 - Accessibility: hide the decorative emoji on empty-state screens (Admin cards, Bans, History) from assistive tech. Screen readers stopped announcing "playing card", "herb" or "heart with ribbon" before the real title and hint.
 - Accessibility: expose the home screen "Almost empty" hint to screen readers. The pile button uses `aria-label`, which replaced its inner text for assistive tech, so the visible low-pile warning was ignored. It is now linked via `aria-describedby` only while the hint is actually shown.
 - Accessibility: link the sign-in and change-password inputs to their error region via `aria-describedby`, and toggle `aria-invalid` on each field while the form holds an error. The password-change "New password" field also links to the strength meter so screen readers reach the live hints when the field is focused.
 - Accessibility: mark the password strength label as an `aria-live="polite"` region and only mutate its text when the tier actually changes. Screen readers now hear the new strength level (Weak, Fair, Good, Strong) once when it shifts, instead of staying silent or spamming every keystroke.
-- Accessibility: add a focus trap, `Escape` to close, backdrop click to close, and focus return to the opener on the admin Create / Edit card modal. This was the remaining bespoke modal that still drove `#modal` directly without the a11y plumbing now shared by the confirmation and deck-sync dialogs.
 
 ### Security
 
@@ -31,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Documentation
 
+- Move the README screenshots from the repository root to `docs/assets/` and render them side by side inside a two-column Markdown table with short captions. The table layout caps each image at half the container width on GitHub without resorting to inline HTML.
 - Spell out in `docs/configuration.md` and `docs/security.md` that `TRUST_PROXY=1` must only be enabled behind a reverse proxy that strips inbound `X-Forwarded-*` headers. Without that, a remote caller can spoof `X-Forwarded-For` and bypass the per-IP rate limits.
 
 ## [1.2.0] - 2026-04-24

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -14,23 +14,25 @@ Audience: maintainers and contributors. This page summarises what the app implem
 
 ### Global
 
-The `<html lang>` attribute is updated whenever the i18n locale changes. Every interactive control is focusable and exposes a visible ring through `:focus-visible`. The first tab stop on the SPA shell is a "Skip to main content" link that moves focus to `<main id="main-content" tabindex="-1">`. Toasts and card announcements live in `role="status"` regions. `prefers-reduced-motion` disables decorative animations, and `prefers-reduced-transparency` removes backdrop blurs.
+The `<html lang>` attribute is updated whenever the i18n locale changes. Every interactive control is focusable and exposes a visible ring through `:focus-visible`. The first tab stop on the SPA shell is a "Skip to main content" link that moves focus to `<main id="main-content" tabindex="-1">`, and focus is moved to that same element after every route change so the new view is announced to screen readers. Toasts and card announcements live in `role="status"` regions. `prefers-reduced-motion` disables decorative animations, and `prefers-reduced-transparency` removes backdrop blurs.
 
 ### Forms
 
-Every `<input>` has an explicit `<label>`. Error messages render inside a `role="alert"` region with `aria-live`. Required fields use the standard `required` attribute. The password strength meter is purely informational: the form never blocks submission based on a visual score alone, because the server is the authority on password validity.
+Every `<input>` has an explicit `<label>`. Error messages render inside a `role="alert"` region with `aria-live`; on the sign-in and change-password forms, each input points at that region via `aria-describedby` and carries `aria-invalid="true"` while the form holds an error. Required fields use the standard `required` attribute. The password strength meter is purely informational: the form never blocks submission based on a visual score alone, because the server is the authority on password validity. The meter's current tier is exposed as an `aria-live="polite"` region that only mutates when the tier actually changes, so screen readers hear each transition between Weak, Fair, Good and Strong without spamming every keystroke.
 
 ### Draw screen
 
-The card title and description are announced through `#card-announce`. Every swipe gesture has a visible button equivalent (Ban, Return and Redraw) that is keyboard-friendly. Arrow keys act as shortcuts while the card is revealed: left arrow bans it, right arrow returns it to the pile. The shortcuts are ignored in preview mode, while the reveal animation is playing, and whenever focus sits inside a text input. Screen readers are informed through `aria-keyshortcuts` on the matching buttons, and the shortcuts honour `prefers-reduced-motion` by skipping the swipe-out animation. `Escape` closes the read-only preview opened from the history screen.
+The card title and description are announced through `#card-announce`, and both elements are tagged with a `lang` attribute reflecting the translation that was actually used, so screen readers switch voice when a card falls back to English under a non-English UI. Every swipe gesture has a visible button equivalent (Ban, Return and Redraw) that is keyboard-friendly. Arrow keys act as shortcuts while the card is revealed: left arrow bans it, right arrow returns it to the pile. The shortcuts are ignored in preview mode, while the reveal animation is playing, and whenever focus sits inside a text input. Screen readers are informed through `aria-keyshortcuts` on the matching buttons, and the shortcuts honour `prefers-reduced-motion` by skipping the swipe-out animation. `Escape` closes the read-only preview opened from the history screen.
 
 ### Modals
 
-Every modal uses `role="dialog"`, `aria-modal="true"` and `aria-labelledby` pointing to the visible title. Focus is trapped inside the modal and `Tab` cycles between the cancel and confirm buttons. `Escape` closes the modal, `Enter` confirms (except when focus is on the Cancel button), and focus is returned to the element that opened the modal once it closes.
+Every modal uses `role="dialog"`, `aria-modal="true"` and `aria-labelledby` pointing to the visible title. Focus is trapped inside the modal's focusables, so `Tab` cycles across every button, input, select and checkbox in the body in addition to the cancel and confirm buttons. `Escape` and a click on the backdrop close the modal, and focus is returned to the element that opened it once it closes. On the shared confirmation dialog, `Enter` also confirms when focus is not on the Cancel button.
 
 ### Navigation
 
 The bottom navigation is a `<nav>` element with a translated `aria-label` in English and French, wrapping an `<ul>` / `<li>` structure so assistive technology announces it as "Main navigation, list of N items". `aria-current="page"` is set on the link of the currently mounted route, updated by the SPA router on every navigation.
+
+The admin page exposes a `role="tablist"` that follows the WAI-ARIA APG tabs pattern: the active tab carries `tabindex="0"` and the others `tabindex="-1"`, so `Tab` moves from the tablist straight into the visible panel rather than cycling across the three headers. `ArrowLeft` / `ArrowRight` wrap around the tablist, `Home` jumps to the first tab and `End` to the last, and every move also focuses the newly selected tab.
 
 ## Manual verification
 


### PR DESCRIPTION
## Summary

Two pre-release hygiene commits.

- **`docs(a11y): sync accessibility.md with the current implementation`**. Five small drifts accumulated between the doc and the code as the recent accessibility fixes landed. The Global section now mentions that focus moves to `#main-content` after every route change. The Forms section describes `aria-describedby` / `aria-invalid` wiring on login and change-password inputs, plus the `aria-live="polite"` label on the password strength meter. The Draw screen section mentions the `lang` attribute on card title and description. The Modals section is rewritten so the focus-trap description matches the current helpers (cycles across every focusable in the body, backdrop click also closes, Enter-to-confirm is kept only on the shared confirmation dialog where it applies). The Navigation section gains a paragraph documenting the admin tablist APG pattern (roving tabindex + arrow keys + Home / End).
- **`docs(changelog): merge duplicate sections in [Unreleased]`**. Two hygiene fixes on the Unreleased block. The two `### Documentation` sections merge into one placed at the end, so Keep a Changelog's one-subsection-per-type rule holds. The two near-identical entries that applied the shared modal a11y pattern to the deck-sync and admin card dialogs collapse into one line. No entry is dropped; wording is preserved for the remaining items.

## Expected behaviors

- Readers opening `docs/accessibility.md` see an accurate picture of what the app currently implements, including the admin-only pieces.
- `[Unreleased]` carries 11 Fixed entries (down from 12), 1 Security entry and 2 Documentation entries grouped in a single subsection.
- No code change, no behaviour change.
