### PR TITLE
chore(release): cut version 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+_Nothing released yet._
+
+## [1.2.1] - 2026-04-24
+
 ### Fixed
 
 - Accessibility: demote the CoupleCards wordmark on `login.html` from `<h1>` to `<div>`. Each login stage (Sign in, Change password) keeps its own `<h1>`, so the document hierarchy now has a single top-level heading per view instead of two.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/csrf-protection": "^7.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "type": "module",
   "description": "CoupleCards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

Patch release bundling every accessibility fix, one security hardening and two documentation tweaks that landed on main since 1.2.0. Semver: all entries are bug fixes or non-breaking improvements, no user-visible new feature, so the patch segment bumps.

- Bump `"version"` to `1.2.1` in `package.json`, `server/package.json`, and the top of both lockfiles (no dependency change).
- Rename the `[Unreleased]` block in `CHANGELOG.md` to `[1.2.1] - 2026-04-24` and reset a fresh empty `[Unreleased]` on top.

## Highlights (see CHANGELOG for the full list)

- **Accessibility (11 fixes)**: heading hierarchy on the login page, associated labels on Settings switches, real skip-to-main link, focus moves to `<main>` after every route change, `lang` attribute on card fallback text, WAI-ARIA APG tabs pattern on the admin tablist, shared focus-trap pattern on the deck-sync and admin card modals, decorative empty-state emoji hidden from screen readers, "Almost empty" hint exposed via `aria-describedby`, form errors wired via `aria-describedby` / `aria-invalid`, password strength announced via `aria-live`.
- **Security**: Argon2id iteration count raised from `t=2` to `t=3`. Existing hashes keep verifying.
- **Documentation**: README screenshots relocated to `docs/assets/` and rendered in a two-column Markdown table; `TRUST_PROXY` caveat documented in `configuration.md` and `security.md`.
