### PR TITLE
fix(admin): make ENABLE_DEMO_ACCOUNT the single lever for the demo account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-_Nothing released yet._
+### Fixed
+
+- `ENABLE_DEMO_ACCOUNT` is now the single source of truth for the demo account. The admin UI refuses to delete the demo row (a new `CANNOT_DELETE_DEMO` error, matching the existing `CANNOT_EDIT_DEMO` / `CANNOT_RESET_DEMO` guards), and the seed step now removes any stale demo row on boot when the flag is off. Previously a delete through the admin UI was undone by the next restart since the seed recreated the row whenever the flag was still set, and unsetting the flag left the demo row in place.
+
+### Documentation
+
+- `docs/security.md` and `docs/administration.md` now state that the demo account is controlled exclusively by `ENABLE_DEMO_ACCOUNT` and describe the new "flag off means the row goes away at the next boot" behaviour.
 
 ## [1.2.1] - 2026-04-24
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -95,12 +95,12 @@ What is deliberately restricted to keep it safe:
 
 - The role is fixed to `user`, so there is no admin visibility and no way to create other users or manage cards.
 - The password cannot be changed. It must stay `demo` for the next visitor.
-- The username cannot be renamed, and the admin cannot reset its password through the UI.
+- The username cannot be renamed, the admin cannot reset its password through the UI, and the delete button is blocked on the demo row too.
 - The bans and history of the demo user are wiped at every sign-in. Anything a visitor does disappears the next time someone signs in as `demo`, so nothing persistent leaks across sessions.
 - A persistent banner is displayed inside the app for as long as the demo user is signed in.
 - The name `demo` is reserved, so no other account can be created with that username.
 
-Because a well-known credential exists while the flag is on, only enable the demo account on public demo instances. Never enable it on a private couple deployment. To disable it, remove the environment variable (or set it to `0`) and delete the `demo` user from the admin panel.
+Because a well-known credential exists while the flag is on, only enable the demo account on public demo instances. Never enable it on a private couple deployment. To disable it, remove the environment variable (or set it to `0`) and restart: the demo row is removed automatically at the next boot. The admin panel does not expose a delete button for the demo account, so the env var is the single lever.
 
 ## Changing the default language
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -62,7 +62,8 @@ Authentication relies on a single factor (password). For a two-person self-hoste
 The optional `demo` account, enabled with `ENABLE_DEMO_ACCOUNT=1`, is a deliberate opt-in credential:
 
 - Anyone who knows the URL can sign in, because the credential is well known by design.
-- The account is restricted to the `user` role, cannot change its password, cannot be renamed, and the admin cannot reset its password through the UI. Rate limiting and lockout apply as they do to any other account.
+- The account is restricted to the `user` role, cannot change its password, cannot be renamed, cannot be deleted from the admin UI, and the admin cannot reset its password through the UI. Rate limiting and lockout apply as they do to any other account.
+- `ENABLE_DEMO_ACCOUNT` is the single source of truth for the demo row. Setting it to `1` seeds the account at the next boot; unsetting it (or setting it to `0`) removes the row at the next boot. That is the only way to disable the demo account on an existing deployment.
 - The `bans` and `history` rows of the demo user are wiped on every sign-in, so nothing a previous visitor did persists across sessions.
 - Safe to expose on a public demo instance. Never enable it on a private deployment.
 

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -186,6 +186,7 @@
   "errors.DEMO_READONLY": "The demo account cannot change its password.",
   "errors.CANNOT_EDIT_DEMO": "The demo account cannot be edited.",
   "errors.CANNOT_RESET_DEMO": "The demo account's password cannot be reset.",
+  "errors.CANNOT_DELETE_DEMO": "The demo account cannot be deleted. Unset the ENABLE_DEMO_ACCOUNT environment variable and restart the instance to disable it.",
   "errors.VALIDATION_ERROR": "Some fields are invalid.",
   "errors.INTERNAL_ERROR": "Internal server error.",
   "errors.page.404.title": "Page not found",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -186,6 +186,7 @@
   "errors.DEMO_READONLY": "Le compte de démonstration ne peut pas changer son mot de passe.",
   "errors.CANNOT_EDIT_DEMO": "Le compte de démonstration ne peut pas être modifié.",
   "errors.CANNOT_RESET_DEMO": "Le mot de passe du compte de démonstration ne peut pas être réinitialisé.",
+  "errors.CANNOT_DELETE_DEMO": "Le compte de démonstration ne peut pas être supprimé. Veuillez retirer la variable d'environnement « ENABLE_DEMO_ACCOUNT » et redémarrez l'instance pour le désactiver.",
   "errors.VALIDATION_ERROR": "Certains champs sont incorrects.",
   "errors.INTERNAL_ERROR": "Erreur interne du serveur.",
   "errors.page.404.title": "Page introuvable",

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v12';
+const VERSION = 'couplecards-v13';
 const SHELL = [
   '/',
   '/index.html',

--- a/server/src/db/seed.js
+++ b/server/src/db/seed.js
@@ -40,8 +40,13 @@ export async function runSeed(logger) {
     logger?.info({ locale }, 'seeded default admin (username=couplecards, password=changeme)');
   }
 
+  // ENABLE_DEMO_ACCOUNT is the single source of truth for the demo row:
+  // flag on seeds it when missing, flag off prunes it when still present.
+  // The admin UI refuses to delete the demo row so the operator points at
+  // the env var rather than at a button that would only last until the
+  // next restart. CASCADE on bans and history cleans up automatically.
   if (config.enableDemoAccount) {
-    const existing = db.prepare('SELECT id FROM users WHERE username = ?').get(DEMO_USERNAME);
+    const existing = db.prepare('SELECT id FROM users WHERE username = ? AND is_demo = 1').get(DEMO_USERNAME);
     if (!existing) {
       const locale = db.prepare("SELECT value FROM settings WHERE key = 'seed_locale'").get()?.value || 'en';
       const hash = await hashPassword(DEMO_PASSWORD);
@@ -50,6 +55,11 @@ export async function runSeed(logger) {
         VALUES (?, ?, 'user', 0, 1, ?)
       `).run(DEMO_USERNAME, hash, locale);
       logger?.info('seeded demo account (username=demo, password=demo) — state resets on each sign-in');
+    }
+  } else {
+    const removed = db.prepare('DELETE FROM users WHERE is_demo = 1').run();
+    if (removed.changes > 0) {
+      logger?.info('ENABLE_DEMO_ACCOUNT is off: removed the demo account row');
     }
   }
 

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -158,10 +158,17 @@ export default async function userRoutes(app) {
     if (id === request.currentUser.id) {
       return reply.code(400).send({ error: 'CANNOT_DELETE_SELF' });
     }
-    const target = db.prepare('SELECT role FROM users WHERE id = ?').get(id);
+    const target = db.prepare('SELECT role, is_demo FROM users WHERE id = ?').get(id);
     if (!target) return reply.code(404).send({ error: 'USER_NOT_FOUND' });
     if (target.role === 'admin') {
       return reply.code(400).send({ error: 'CANNOT_DELETE_ADMIN' });
+    }
+    // The demo account is controlled by ENABLE_DEMO_ACCOUNT. Deleting the row
+    // would only last until the next restart, since the seed step recreates it
+    // whenever the flag is set. Refuse the delete so the admin points at the
+    // right lever (unset the env var and restart).
+    if (target.is_demo === 1) {
+      return reply.code(400).send({ error: 'CANNOT_DELETE_DEMO' });
     }
     db.prepare('DELETE FROM users WHERE id = ?').run(id);
     return { ok: true };


### PR DESCRIPTION
## Summary

Close a pair of related gaps around the demo account lifecycle.

- **`fix(admin): block deletion of the demo account`**. `DELETE /users/:id` used to accept the demo row. That was inconsistent with the existing `CANNOT_EDIT_DEMO` and `CANNOT_RESET_DEMO` guards, and worse, the delete only "worked" until the next restart, since the seed step recreated the row as long as `ENABLE_DEMO_ACCOUNT` was still set. A new `CANNOT_DELETE_DEMO` error matches the other demo-specific errors, with translations in both locales.
- **`fix(server): remove the demo row on boot when ENABLE_DEMO_ACCOUNT is off`**. The seed step already recreated the demo row at boot when the flag was on; it never cleaned it up when the flag was off. So a deployment that had once enabled the demo kept a usable demo login until the row was manually removed. The seed step now deletes any `is_demo=1` row on boot when the flag is off. `ON DELETE CASCADE` on `bans` and `history` handles the state cleanup.
- **`docs: document ENABLE_DEMO_ACCOUNT as the single source of truth`**. `docs/security.md` and `docs/administration.md` still described the pre-change flow (admin deletes the row through the UI). Both now say the flag is the only lever: set it to enable, unset it and restart to disable. The admin panel's delete button is blocked on the demo row.

## Expected behaviors

- Clicking Delete on the demo account in the admin panel shows a translated error and leaves the row in place.
- With `ENABLE_DEMO_ACCOUNT=0` (or unset), the next container restart removes the demo row automatically, along with its bans and history, and logs a single info line.
- With `ENABLE_DEMO_ACCOUNT=1`, behaviour is unchanged: the demo row is seeded on first boot if missing, and state resets at every sign-in.
- No impact on regular user accounts, on the `demo` username reservation, or on the admin's own account.

## Notes

- Service worker cache version bumped `v12` → `v13` so clients pick up the new locale key for the error message.
