### PR TITLE
fix(admin): balance the spacing around the Add a card button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - `ENABLE_DEMO_ACCOUNT` is now the single source of truth for the demo account. The admin UI refuses to delete the demo row (a new `CANNOT_DELETE_DEMO` error, matching the existing `CANNOT_EDIT_DEMO` / `CANNOT_RESET_DEMO` guards), and the seed step now removes any stale demo row on boot when the flag is off. Previously a delete through the admin UI was undone by the next restart since the seed recreated the row whenever the flag was still set, and unsetting the flag left the demo row in place.
+- Admin Cards panel: balance the spacing around the "Add a card" button. It previously had 28 px of visual gap above and 40 px below, because the button carried a 14 px vertical margin on top of the panel's flex gap while the list below added another 12 px of internal top padding for its fade mask. The button now offsets by 12 px on top only, so both gaps settle at 26 px.
 
 ### Documentation
 

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -231,7 +231,12 @@ body { padding: 20px 16px calc(env(safe-area-inset-bottom, 0px) + 24px); }
 }
 #admin-create-card-btn {
   align-self: flex-end;
-  margin: 14px 0;
+  /* The admin panel adds a 14px flex gap between every pair of children,
+     and the list below has 12px of internal top padding (for its fade
+     mask). That made the visual gap above the button (14) smaller than
+     the gap below it (14 + 12). Offset the button by 12px on top only,
+     so both sides settle at 26px. */
+  margin-top: 12px;
 }
 
 .field-group {

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v13';
+const VERSION = 'couplecards-v14';
 const SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

The "Add a card" button on the admin Cards tab had 28 px of visual gap above and 40 px below. The admin panel already contributes a 14 px flex gap between every pair of children, the button piled another 14 px of vertical margin on top, and the list container below adds 12 px of internal top padding for its fade mask. That made the gap under the button 12 px taller than the gap above it and read as misaligned.

Replace the symmetric 14 px margin with a 12 px top-only offset, so both gaps settle at 26 px.

## Expected behaviors

- The "Add a card" button sits with the same amount of space above and below it on the Cards tab.
- No impact on any other button or tile, and no change to the panel's own flex gap.

## Notes

- Service worker cache version bumped `v12` → `v13` so clients pick up the new `admin.css`.
- Conflicts with `fix/admin-cannot-delete-demo` on the `sw.js` version constant and on the `[Unreleased]` section of the `CHANGELOG`. Whichever branch merges first keeps `v13`; the second needs a trivial rebase to `v14` and appending its entry under `[Unreleased]`.
