### PR TITLE
chore(release): cut version 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+_Nothing released yet._
+
+## [1.2.2] - 2026-04-24
+
 ### Fixed
 
 - `ENABLE_DEMO_ACCOUNT` is now the single source of truth for the demo account. The admin UI refuses to delete the demo row (a new `CANNOT_DELETE_DEMO` error, matching the existing `CANNOT_EDIT_DEMO` / `CANNOT_RESET_DEMO` guards), and the seed step now removes any stale demo row on boot when the flag is off. Previously a delete through the admin UI was undone by the next restart since the seed recreated the row whenever the flag was still set, and unsetting the flag left the demo row in place.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@fastify/csrf-protection": "^7.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "description": "CoupleCards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

Patch release bundling the two bug fixes that landed on main since 1.2.1. Semver: both are non-breaking fixes with no new user-visible feature, so the patch segment bumps.

- Bump `"version"` to `1.2.2` in `package.json`, `server/package.json`, and the top of both lockfiles (no dependency change).
- Rename the `[Unreleased]` block in `CHANGELOG.md` to `[1.2.2] - 2026-04-24` and reset a fresh empty `[Unreleased]` on top.

## Highlights (see CHANGELOG for the full list)

- `ENABLE_DEMO_ACCOUNT` is now the single source of truth for the demo account: the admin UI refuses to delete the demo row (new `CANNOT_DELETE_DEMO` error), and the seed step removes any stale demo row at boot when the flag is off.
- Admin Cards panel: balance the spacing around the "Add a card" button so both sides settle at 26 px.
- Documentation: `docs/security.md` and `docs/administration.md` updated to describe the new demo-account lifecycle.
