### PR TITLE
chore(release): cut version 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+_Nothing released yet._
+
+## [1.3.0] - 2026-04-27
+
 ### Changed
 
 - Swap the serif Literata for **Fraunces** as the display font. The CoupleCards wordmark on the home header, login screen, boot splash, and draw screen now uses Fraunces' soft-and-wonky variant (`font-variation-settings: "SOFT" 100, "WONK" 1, "opsz" 144`) with a soft pink glow. Section headings (Settings, Rules, Bans, History, Administration) are demoted to the body Inter face so they no longer compete visually with the wordmark, and `.auth-title` ("Sign in", "Change your password") follows the same neutral style. Card text keeps a serif feel by using the standard rendering of Fraunces. The 14 Literata WOFF2 files are removed; Fraunces ships with Latin, Latin Extended, and Vietnamese subsets. Greek and Cyrillic are not part of the Fraunces upstream, so locales using those scripts now fall back to Georgia / serif.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/csrf-protection": "^7.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "description": "CoupleCards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

Bump to **1.3.0** to package the typography overhaul and UI polish merged this round (PR du logo Fraunces, polish admin, fix login error message, refresh README).

- `package.json` + `server/package.json` → `1.3.0`
- `package-lock.json` + `server/package-lock.json` (top + `packages.""`) → `1.3.0`. No dependency changes.
- `CHANGELOG.md`: `[Unreleased]` block renamed to `[1.3.0] - 2026-04-27`, fresh empty `[Unreleased]` added above.

## Test plan

- [ ] CI `build` passes on the release commit.
- [ ] After merge, the GHCR Docker publish workflow attached to the GitHub Release picks up the new tag and builds `ghcr.io/qiaeru/couplecards:1.3.0`.
