### PR TITLE
chore(deps): replace jszip with fflate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-_Nothing released yet._
+### Changed
+
+- Replace `jszip` (last release March 2023) with `fflate` for the admin deck export and import paths. fflate is actively maintained, MIT-licensed, and ~18x smaller in the lazy-loaded vendor bundle (5.3 KB versus ~96 KB). The ZIP wire format is unchanged, so previously downloaded `couplecards-deck-*.zip` backups remain importable. The `public/vendor/jszip.js` artefact is replaced by `public/vendor/fflate.js`.
+- Service Worker bumped to `couplecards-v16` to invalidate caches that still hold the old `deck-sync.js` referencing `/vendor/jszip.js`.
 
 ## [1.3.0] - 2026-04-27
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -23,6 +23,7 @@ The full OFL text ships with the repository at `public/fonts/OFL.txt`.
 - [@fastify/static](https://github.com/fastify/fastify-static). MIT licence.
 - [hash-wasm](https://github.com/Daninet/hash-wasm). MIT licence. Provides Argon2id through a pure WebAssembly implementation, so the backend needs no native compilation.
 - [@zxcvbn-ts/core and its dictionaries](https://github.com/zxcvbn-ts/zxcvbn) (`language-common`, `language-en`, `language-fr`). MIT licence.
+- [fflate](https://github.com/101arrowz/fflate). MIT licence. Used to build and parse the deck export ZIP on the backend, and bundled into `public/vendor/fflate.js` for the admin import dialog.
 
 The SQLite engine is the one bundled with Node.js itself, exposed as the `node:sqlite` module, and covered by the [Node.js MIT licence](https://github.com/nodejs/node/blob/main/LICENSE).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,7 +122,7 @@ The procedure to add a third language is documented end-to-end in [i18n.md](./i1
 
 ## Why vanilla JavaScript and no build step for source
 
-A zero client-side toolchain keeps the contribution barrier low. A text editor and a browser are enough to edit any feature. The only build step is the vendor bundle produced by `scripts/build-vendor.mjs`, which currently packages the zxcvbn core and the JSZip library used by the admin deck import dialog. Both are invoked automatically during the Docker build.
+A zero client-side toolchain keeps the contribution barrier low. A text editor and a browser are enough to edit any feature. The only build step is the vendor bundle produced by `scripts/build-vendor.mjs`, which currently packages the zxcvbn core and the fflate library used by the admin deck import dialog. Both are invoked automatically during the Docker build.
 
 ## Seeding and upgrades
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@zxcvbn-ts/language-en": "^3.0.2",
         "@zxcvbn-ts/language-fr": "^3.0.2",
         "esbuild": "^0.28.0",
-        "jszip": "^3.10.1"
+        "fflate": "^0.8.2"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -493,13 +493,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/esbuild": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
@@ -552,108 +545,10 @@
         "node": ">= 4.9.1"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jszip": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dev": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true,
-      "license": "(MIT AND Zlib)"
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "add-spdx": "node scripts/add-spdx.mjs"
   },
   "devDependencies": {
-    "esbuild": "^0.28.0",
-    "jszip": "^3.10.1",
     "@zxcvbn-ts/core": "^3.0.4",
     "@zxcvbn-ts/language-common": "^3.0.4",
     "@zxcvbn-ts/language-en": "^3.0.2",
-    "@zxcvbn-ts/language-fr": "^3.0.2"
+    "@zxcvbn-ts/language-fr": "^3.0.2",
+    "esbuild": "^0.28.0",
+    "fflate": "^0.8.2"
   }
 }

--- a/public/js/features/admin/deck-sync.js
+++ b/public/js/features/admin/deck-sync.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Deck maintenance flows: export (ZIP), sync from server-side JSON files,
-// import an uploaded backup. JSZip is loaded lazily when importing.
+// import an uploaded backup. fflate is loaded lazily when importing.
 
 import { request, ApiError } from '../../core/api.js';
 import { t } from '../../core/i18n.js';
@@ -8,7 +8,7 @@ import { toast } from '../../ui/shell.js';
 
 const MAX_IMPORT_BYTES = 2 * 1024 * 1024;
 const SUPPORTED_LOCALES = ['en', 'fr'];
-let jszipPromise = null;
+let fflatePromise = null;
 
 function escapeHtml(s) {
   return String(s).replace(/[&<>"']/g, (c) => ({
@@ -24,11 +24,11 @@ function errorMessage(err) {
   return t('errors.generic');
 }
 
-async function loadJSZip() {
-  if (!jszipPromise) {
-    jszipPromise = import('/vendor/jszip.js').then((m) => m.default);
+async function loadFflate() {
+  if (!fflatePromise) {
+    fflatePromise = import('/vendor/fflate.js');
   }
-  return jszipPromise;
+  return fflatePromise;
 }
 
 export async function exportDeck() {
@@ -345,16 +345,16 @@ async function parseBackup(file) {
   if (file.size > MAX_IMPORT_BYTES) throw new Error('INVALID_DECK');
   const lower = file.name.toLowerCase();
   if (lower.endsWith('.zip') || file.type === 'application/zip') {
-    const JSZip = await loadJSZip();
-    const zip = await JSZip.loadAsync(await file.arrayBuffer());
+    const { unzipSync, strFromU8 } = await loadFflate();
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const entries = unzipSync(bytes);
     const cardsByLocale = {};
-    for (const [name, entry] of Object.entries(zip.files)) {
+    for (const [name, data] of Object.entries(entries)) {
       const match = /^cards\.([a-z]{2})\.json$/i.exec(name.split('/').pop());
       if (!match) continue;
       const locale = match[1].toLowerCase();
       if (!SUPPORTED_LOCALES.includes(locale)) continue;
-      const text = await entry.async('string');
-      const payload = JSON.parse(text);
+      const payload = JSON.parse(strFromU8(data));
       if (!Array.isArray(payload?.cards)) throw new Error('INVALID_DECK');
       cardsByLocale[locale] = payload.cards;
     }

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v15';
+const VERSION = 'couplecards-v16';
 const SHELL = [
   '/',
   '/index.html',

--- a/scripts/build-vendor.mjs
+++ b/scripts/build-vendor.mjs
@@ -19,9 +19,9 @@ const bundles = [
     outfile: resolve(outDir, 'zxcvbn.js'),
   },
   {
-    name: 'jszip',
-    entry: resolve(root, 'scripts/vendor-entry-jszip.js'),
-    outfile: resolve(outDir, 'jszip.js'),
+    name: 'fflate',
+    entry: resolve(root, 'scripts/vendor-entry-fflate.js'),
+    outfile: resolve(outDir, 'fflate.js'),
   },
 ];
 

--- a/scripts/vendor-entry-fflate.js
+++ b/scripts/vendor-entry-fflate.js
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// esbuild entry that re-exports the fflate primitives we need in the browser.
+// Only loaded by the admin panel when the Import a backup dialog needs to
+// unzip a deck.
+
+export { unzipSync, strFromU8 } from 'fflate';

--- a/scripts/vendor-entry-jszip.js
+++ b/scripts/vendor-entry-jszip.js
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: MIT
-// esbuild entry that re-exports JSZip for the browser. Only loaded by the
-// admin panel when the Import a backup dialog needs to unzip a deck.
-
-import JSZip from 'jszip';
-
-export default JSZip;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,8 +19,8 @@
         "@zxcvbn-ts/language-en": "^3.0.2",
         "@zxcvbn-ts/language-fr": "^3.0.2",
         "fastify": "^5.8.5",
-        "hash-wasm": "^4.12.0",
-        "jszip": "^3.10.1"
+        "fflate": "^0.8.2",
+        "hash-wasm": "^4.12.0"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -622,12 +622,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -795,6 +789,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/find-my-way": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
@@ -861,12 +861,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "license": "MIT"
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -881,12 +875,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
     },
     "node_modules/json-schema-ref-resolver": {
       "version": "3.0.0",
@@ -912,27 +900,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
-    },
-    "node_modules/jszip": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "dependencies": {
-        "lie": "~3.3.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/lie": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
     },
     "node_modules/light-my-request": {
       "version": "6.6.0",
@@ -1025,12 +992,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/path-scurry": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
@@ -1084,12 +1045,6 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -1111,21 +1066,6 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",
@@ -1180,12 +1120,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "license": "MIT"
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/safe-regex2": {
@@ -1253,12 +1187,6 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "license": "MIT"
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -1317,15 +1245,6 @@
         "text-decoder": "^1.1.0"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/teex": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
@@ -1373,12 +1292,6 @@
       "engines": {
         "node": ">=0.6"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/which-runtime": {
       "version": "1.3.2",

--- a/server/package.json
+++ b/server/package.json
@@ -28,7 +28,7 @@
     "@zxcvbn-ts/language-en": "^3.0.2",
     "@zxcvbn-ts/language-fr": "^3.0.2",
     "fastify": "^5.8.5",
-    "hash-wasm": "^4.12.0",
-    "jszip": "^3.10.1"
+    "fflate": "^0.8.2",
+    "hash-wasm": "^4.12.0"
   }
 }

--- a/server/src/routes/admin-cards.js
+++ b/server/src/routes/admin-cards.js
@@ -4,7 +4,8 @@
 // the database from the seed files shipped under data/, or import an uploaded
 // backup (already parsed into the internal multilingual shape by the client).
 
-import JSZip from 'jszip';
+import { promisify } from 'node:util';
+import { zip as zipCb, strToU8 } from 'fflate';
 import { requireAdmin } from '../lib/auth.js';
 import {
   readSeedDecks,
@@ -16,6 +17,7 @@ import {
 } from '../lib/deckSync.js';
 import { SUPPORTED_LOCALES } from '../lib/locales.js';
 
+const zipAsync = promisify(zipCb);
 const DECK_ERRORS = new Set(['SEED_FILE_NOT_FOUND', 'INVALID_DECK', 'INVALID_MODE']);
 
 function handleDeckError(err, reply) {
@@ -28,16 +30,13 @@ function handleDeckError(err, reply) {
 export default async function adminCardRoutes(app) {
   app.get('/cards/export', { preHandler: requireAdmin }, async (_request, reply) => {
     const byLocale = serialiseForExport();
-    const zip = new JSZip();
+    const entries = {};
     for (const locale of SUPPORTED_LOCALES) {
       const payload = { version: 1, cards: byLocale[locale] ?? [] };
-      zip.file(`cards.${locale}.json`, `${JSON.stringify(payload, null, 2)}\n`);
+      entries[`cards.${locale}.json`] = strToU8(`${JSON.stringify(payload, null, 2)}\n`);
     }
-    const buffer = await zip.generateAsync({
-      type: 'nodebuffer',
-      compression: 'DEFLATE',
-      compressionOptions: { level: 6 },
-    });
+    const zipped = await zipAsync(entries, { level: 6 });
+    const buffer = Buffer.from(zipped);
     const stamp = new Date().toISOString().slice(0, 10);
     reply.header('Content-Type', 'application/zip');
     reply.header('Content-Disposition', `attachment; filename="couplecards-deck-${stamp}.zip"`);


### PR DESCRIPTION
## Summary

- Swap `jszip` (last release March 2023) for `fflate` in the admin deck export (backend) and import (frontend) paths.
- Lazy-loaded vendor bundle shrinks from ~96 KB to 5.3 KB, ~18x smaller.
- The ZIP wire format is unchanged; previously downloaded `couplecards-deck-*.zip` backups remain importable. Verified by round-tripping a JSZip-produced archive through fflate.

## Scope

- `server/src/routes/admin-cards.js`: backend export now uses `fflate.zip` (DEFLATE level 6 preserved).
- `public/js/features/admin/deck-sync.js`: frontend import now lazy-loads `/vendor/fflate.js` and uses `unzipSync` + `strFromU8`.
- `scripts/vendor-entry-jszip.js` removed; `scripts/vendor-entry-fflate.js` added; `scripts/build-vendor.mjs` updated.
- Service Worker bumped to `couplecards-v16` so installed admins fetch the new `deck-sync.js` instead of the cached version still referencing `/vendor/jszip.js`.
- `package.json` (root and server), `CHANGELOG.md`, `CREDITS.md`, `docs/architecture.md`, `CLAUDE.md` updated.

## Expected behaviour

- Admin Export deck downloads the same multilingual ZIP layout (`cards.<locale>.json` per supported locale).
- Admin Import a backup accepts both fflate-produced ZIPs (new exports) and JSZip-produced ZIPs (existing user backups).
- First admin to load the panel after deploy fetches `/vendor/fflate.js` instead of `/vendor/jszip.js`; the latter is no longer served.
- No data migration: card rows, translations, sessions, hashes are untouched.
