### PR TITLE
chore(release): cut version 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+_Nothing released yet._
+
+## [1.4.0] - 2026-04-28
+
 ### Added
 
 - Three new locales shipped end-to-end: German, Italian and Spanish. Each comes with a full UI catalogue (`public/locales/<locale>.json`), a card deck (`data/cards.<locale>.json`), a translated web manifest, an entry in the in-app language selector, and a SQLite migration (`002_locales_de_it_es.sql`) that widens the locale CHECK constraint on `users.locale` and `card_translations.locale`. Translations follow the FR-source, target-language-naturalised rule.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/csrf-protection": "^7.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "description": "CoupleCards backend — Fastify + node:sqlite",


### PR DESCRIPTION
Cuts version 1.4.0. Bumps `package.json` / `server/package.json` and the corresponding lockfiles, promotes the `[Unreleased]` block to `[1.4.0] - 2026-04-28` in the CHANGELOG, and adds a fresh empty `[Unreleased]` above it. No code or asset changes.

See the `[1.4.0]` section of `CHANGELOG.md` for the full set of changes shipped in this version.
