### PR TITLE
chore(brand): lowercase wordmark to Couplecards, drop PWA caveat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-_Nothing released yet._
+### Changed
+
+- Wordmark and brand name lowercased to **Couplecards** for a more modern feel. Applies to the home/login/boot/draw wordmark, page titles, web manifests (`name` / `short_name` across all five locales), locale catalogues (`app.name`, `draw.title`), and prose in the README, CHANGELOG header, contributing guide, credits, and `docs/`. Past CHANGELOG entries keep the original `CoupleCards` spelling. Service Worker bumped to `couplecards-v22` so the new HTML and manifests refresh on existing installs.
 
 ## [1.4.0] - 2026-04-28
 
@@ -166,3 +168,9 @@ _Nothing released yet._
 ### Fixed
 
 - Container crashed on startup with `ADDON_NOT_FOUND` for `sodium-native` (pulled in by `@fastify/secure-session`). Switched the Docker image from `node:24-alpine` (musl) to `node:24-slim` (glibc) on all three build stages, since sodium-native's musl prebuilds are not reliably fetched by npm. Package manager calls (`apk` → `apt-get`), user creation (`adduser -S` → `useradd --system`), and the `tini` path (`/sbin/tini` → `/usr/bin/tini`) were adapted accordingly.
+
+## [1.0.0] - 2026-04-23
+
+### Added
+
+- Initial release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to CoupleCards
+# Contributing to Couplecards
 
 Thank you for considering a contribution. The project is intentionally small and must stay approachable to non-technical maintainers who run their own instance. Changes that keep it simple are the ones most likely to land.
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,6 +1,6 @@
 # Credits
 
-CoupleCards is released under the [MIT License](./LICENSE). Every third-party asset and library it ships is distributed under an OSI-approved or FSF-approved open source licence. No CDN is contacted at runtime.
+Couplecards is released under the [MIT License](./LICENSE). Every third-party asset and library it ships is distributed under an OSI-approved or FSF-approved open source licence. No CDN is contacted at runtime.
 
 ## Fonts
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CoupleCards
+# Couplecards
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Release](https://img.shields.io/github/v/release/qiaeru/couplecards)](https://github.com/qiaeru/couplecards/releases)
@@ -19,7 +19,7 @@ A hosted demo is available at **<https://couplecards.qiaeru.com/>**. Sign in wit
 
 | Home | Reveal |
 | :--: | :----: |
-| ![CoupleCards home screen with the two piles](./docs/assets/screenshot1.png) | ![A drawn CoupleCards card](./docs/assets/screenshot2.png) |
+| ![Couplecards home screen with the two piles](./docs/assets/screenshot1.png) | ![A drawn Couplecards card](./docs/assets/screenshot2.png) |
 | *The two piles on the home screen* | *A card revealed from the deck* |
 
 ## Highlights

--- a/deploy/caddy/README.md
+++ b/deploy/caddy/README.md
@@ -1,6 +1,6 @@
-# CoupleCards behind Caddy (HTTPS)
+# Couplecards behind Caddy (HTTPS)
 
-This is the simplest way to expose CoupleCards over HTTPS. Caddy negotiates a Let's Encrypt certificate automatically on first start, with no extra tooling.
+This is the simplest way to expose Couplecards over HTTPS. Caddy negotiates a Let's Encrypt certificate automatically on first start, with no extra tooling.
 
 ## Prerequisites
 

--- a/deploy/nginx/README.md
+++ b/deploy/nginx/README.md
@@ -1,4 +1,4 @@
-# CoupleCards behind nginx (HTTPS)
+# Couplecards behind nginx (HTTPS)
 
 This variant targets hosts that already run nginx and prefer to manage their Let's Encrypt certificates with `certbot`.
 

--- a/deploy/traefik/README.md
+++ b/deploy/traefik/README.md
@@ -1,4 +1,4 @@
-# CoupleCards behind Traefik (HTTPS)
+# Couplecards behind Traefik (HTTPS)
 
 This variant uses Traefik v3 with the Let's Encrypt HTTP-01 challenge and an automatic redirect from HTTP to HTTPS.
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -84,7 +84,7 @@ Every sync or import runs inside a single database transaction, so a failure mid
 
 ## The shared demo account
 
-CoupleCards can seed an extra shared account named `demo` with the password `demo`, so visitors can try the app without touching the couple's data. This account is disabled by default and must be enabled explicitly at deploy time by setting the `ENABLE_DEMO_ACCOUNT=1` environment variable. See [configuration.md](./configuration.md) for the complete variable reference.
+Couplecards can seed an extra shared account named `demo` with the password `demo`, so visitors can try the app without touching the couple's data. This account is disabled by default and must be enabled explicitly at deploy time by setting the `ENABLE_DEMO_ACCOUNT=1` environment variable. See [configuration.md](./configuration.md) for the complete variable reference.
 
 What the demo account can do:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-Audience: self-hosters running CoupleCards on their own server.
+Audience: self-hosters running Couplecards on their own server.
 
 ## Prerequisites
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -4,7 +4,7 @@ Audience: contributors who want to add a new language or polish an existing one.
 
 ## Supported locales and source of truth
 
-CoupleCards ships five locales out of the box: French (the source of truth), English (the fallback), German, Italian and Spanish. The authoritative list lives in the backend at [`server/src/lib/locales.js`](../server/src/lib/locales.js) (`SUPPORTED_LOCALES`). The frontend mirrors the same list inside the `SUPPORTED` set of [`public/js/core/i18n.js`](../public/js/core/i18n.js), exposed through `supportedLocales()`. Adding a language means updating both files, along with the storage layer described in [Step 3](#step-3-card-translations).
+Couplecards ships five locales out of the box: French (the source of truth), English (the fallback), German, Italian and Spanish. The authoritative list lives in the backend at [`server/src/lib/locales.js`](../server/src/lib/locales.js) (`SUPPORTED_LOCALES`). The frontend mirrors the same list inside the `SUPPORTED` set of [`public/js/core/i18n.js`](../public/js/core/i18n.js), exposed through `supportedLocales()`. Adding a language means updating both files, along with the storage layer described in [Step 3](#step-3-card-translations).
 
 **Never hardcode the locale list anywhere else.** Any consumer that needs to iterate over supported languages must import `SUPPORTED_LOCALES` (server) or call `supportedLocales()` (client). A `const SUPPORTED_LOCALES = ['en', 'fr']` literal sitting in a feature module is a bug: it silently freezes that feature to two locales the next time the canonical list grows. Run `grep -rn "SUPPORTED_LOCALES *=" public/js server/src` after adding a language to confirm there are no rogue copies.
 
@@ -48,8 +48,6 @@ The server negotiates the manifest based on the request's `Accept-Language` head
 1. Copy [`public/manifest.en.webmanifest`](../public/manifest.en.webmanifest) to `public/manifest.<code>.webmanifest`.
 2. Translate the `name`, `short_name` and `description` fields.
 3. Extend the negotiation inside [`server/src/routes/manifest.js`](../server/src/routes/manifest.js) so the new code is matched against `Accept-Language`.
-
-A limitation of the PWA spec is worth knowing: once the app is installed on a device, the displayed name is fixed to the manifest served at install time. Changing the in-app language later does not rename the icon on the home screen. This is a browser-side constraint, not a CoupleCards one.
 
 ### Step 3. Card translations
 

--- a/public/404.html
+++ b/public/404.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#1a0f35">
-  <title>CoupleCards — Not found</title>
+  <title>Couplecards — Not found</title>
   <link rel="stylesheet" href="/css/fonts.css">
   <link rel="stylesheet" href="/css/themes.css">
   <link rel="stylesheet" href="/css/style.css">

--- a/public/500.html
+++ b/public/500.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#1a0f35">
-  <title>CoupleCards — Server error</title>
+  <title>Couplecards — Server error</title>
   <link rel="stylesheet" href="/css/fonts.css">
   <link rel="stylesheet" href="/css/themes.css">
   <link rel="stylesheet" href="/css/style.css">

--- a/public/admin.html
+++ b/public/admin.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#1a0f35">
-  <title>CoupleCards — Administration</title>
+  <title>Couplecards — Administration</title>
   <link rel="stylesheet" href="/css/fonts.css">
   <link rel="stylesheet" href="/css/themes.css">
   <link rel="stylesheet" href="/css/style.css">
@@ -15,7 +15,7 @@
 </head>
 <body>
   <div id="admin-boot" class="boot-skeleton">
-    <div class="boot-logo"><img class="title-icon" src="/icons/icon.svg" alt="" aria-hidden="true" draggable="false"><span>CoupleCards</span></div>
+    <div class="boot-logo"><img class="title-icon" src="/icons/icon.svg" alt="" aria-hidden="true" draggable="false"><span>Couplecards</span></div>
     <div class="boot-pulse"></div>
   </div>
 

--- a/public/css/fonts.css
+++ b/public/css/fonts.css
@@ -11,7 +11,7 @@
   font-display: swap;
 }
 
-/* Fraunces — display font for headings, the CoupleCards wordmark, and card
+/* Fraunces — display font for headings, the Couplecards wordmark, and card
    text. Variable axes: wght / opsz / SOFT / WONK (the wordmark uses the soft
    and wonky variant; everything else gets the standard rendering).
    Coverage: Latin, Latin Extended, Vietnamese. Fraunces upstream does NOT

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -200,7 +200,7 @@ body::before {
   -webkit-user-drag: none;
 }
 
-/* CoupleCards wordmark: home header, login screen, boot splash, draw screen.
+/* Couplecards wordmark: home header, login screen, boot splash, draw screen.
    Single rule so size / weight / glow / variation axes stay in sync. */
 .app-header.app-header-home .title,
 .brand-title,

--- a/public/index.html
+++ b/public/index.html
@@ -10,8 +10,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#1a0f35">
-  <meta name="description" data-i18n-attr="content:app.name" content="CoupleCards">
-  <title>CoupleCards</title>
+  <meta name="description" data-i18n-attr="content:app.name" content="Couplecards">
+  <title>Couplecards</title>
 
   <link rel="stylesheet" href="/css/fonts.css">
   <link rel="stylesheet" href="/css/themes.css">
@@ -26,14 +26,14 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <meta name="apple-mobile-web-app-title" content="CoupleCards">
+  <meta name="apple-mobile-web-app-title" content="Couplecards">
 </head>
 <body>
   <a href="#main-content" class="skip-link" data-i18n="common.skipToContent">Skip to main content</a>
   <div id="screen-announce" class="sr-only" role="status" aria-live="polite"></div>
 
   <div id="boot-skeleton" class="boot-skeleton">
-    <div class="boot-logo"><img class="title-icon" src="/icons/icon.svg" alt="" aria-hidden="true" draggable="false"><span>CoupleCards</span></div>
+    <div class="boot-logo"><img class="title-icon" src="/icons/icon.svg" alt="" aria-hidden="true" draggable="false"><span>Couplecards</span></div>
     <div class="boot-pulse"></div>
   </div>
 

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -1,5 +1,5 @@
 {
-  "app.name": "CoupleCards",
+  "app.name": "Couplecards",
   "common.loading": "Wird geladen…",
   "common.cancel": "Abbrechen",
   "common.undo": "Rückgängig",
@@ -50,7 +50,7 @@
   "home.pile.home.aria": "Aus dem Stapel „Zuhause\" ziehen",
   "home.pile.outdoor.aria": "Aus dem Stapel „Draußen\" ziehen",
   "home.pile.lowHint": "Fast leer",
-  "draw.title": "CoupleCards",
+  "draw.title": "Couplecards",
   "draw.action.ban": "Verbannen",
   "draw.action.return": "Auf den Stapel zurücklegen",
   "draw.action.redraw": "Eine weitere Karte aus demselben Stapel ziehen",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1,5 +1,5 @@
 {
-  "app.name": "CoupleCards",
+  "app.name": "Couplecards",
   "common.loading": "Loading…",
   "common.cancel": "Cancel",
   "common.undo": "Undo",
@@ -50,7 +50,7 @@
   "home.pile.home.aria": "Draw from the \"Home\" pile",
   "home.pile.outdoor.aria": "Draw from the \"Outdoor\" pile",
   "home.pile.lowHint": "Almost empty",
-  "draw.title": "CoupleCards",
+  "draw.title": "Couplecards",
   "draw.action.ban": "Ban",
   "draw.action.return": "Return to the pile",
   "draw.action.redraw": "Draw another from the same pile",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -1,5 +1,5 @@
 {
-  "app.name": "CoupleCards",
+  "app.name": "Couplecards",
   "common.loading": "Cargando…",
   "common.cancel": "Cancelar",
   "common.undo": "Deshacer",
@@ -50,7 +50,7 @@
   "home.pile.home.aria": "Robar del montón «Casa»",
   "home.pile.outdoor.aria": "Robar del montón «Fuera»",
   "home.pile.lowHint": "Casi vacío",
-  "draw.title": "CoupleCards",
+  "draw.title": "Couplecards",
   "draw.action.ban": "Vetar",
   "draw.action.return": "Devolver al montón",
   "draw.action.redraw": "Robar otra carta del mismo montón",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -1,5 +1,5 @@
 {
-  "app.name": "CoupleCards",
+  "app.name": "Couplecards",
   "common.loading": "Chargement…",
   "common.cancel": "Annuler",
   "common.undo": "Annuler",
@@ -50,7 +50,7 @@
   "home.pile.home.aria": "Piocher dans le tas « Domicile »",
   "home.pile.outdoor.aria": "Piocher dans le tas « Extérieur »",
   "home.pile.lowHint": "Presque vide",
-  "draw.title": "CoupleCards",
+  "draw.title": "Couplecards",
   "draw.action.ban": "Bannir",
   "draw.action.return": "Remettre dans la pioche",
   "draw.action.redraw": "Piocher une autre carte du même tas",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -1,5 +1,5 @@
 {
-  "app.name": "CoupleCards",
+  "app.name": "Couplecards",
   "common.loading": "Caricamento…",
   "common.cancel": "Annulla",
   "common.undo": "Annulla",
@@ -50,7 +50,7 @@
   "home.pile.home.aria": "Pesca dal mazzo «Casa»",
   "home.pile.outdoor.aria": "Pesca dal mazzo «Fuori»",
   "home.pile.lowHint": "Quasi vuoto",
-  "draw.title": "CoupleCards",
+  "draw.title": "Couplecards",
   "draw.action.ban": "Banna",
   "draw.action.return": "Rimetti nel mazzo",
   "draw.action.redraw": "Pesca un'altra carta dallo stesso mazzo",

--- a/public/login.html
+++ b/public/login.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#1a0f35">
-  <title>CoupleCards — Sign in</title>
+  <title>Couplecards — Sign in</title>
   <link rel="stylesheet" href="/css/fonts.css">
   <link rel="stylesheet" href="/css/themes.css">
   <link rel="stylesheet" href="/css/style.css">
@@ -19,7 +19,7 @@
   <main class="auth-shell">
     <div class="brand-title">
       <img class="title-icon" src="/icons/icon.svg" alt="" aria-hidden="true" draggable="false">
-      <span data-i18n="app.name">CoupleCards</span>
+      <span data-i18n="app.name">Couplecards</span>
     </div>
     <section class="auth-card" id="step-login" hidden>
       <h1 class="auth-title" data-i18n="login.title">Sign in</h1>

--- a/public/manifest.de.webmanifest
+++ b/public/manifest.de.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "CoupleCards",
-  "short_name": "CoupleCards",
+  "name": "Couplecards",
+  "short_name": "Couplecards",
   "description": "Selbst gehostete Web-App, mit der Paare Aktivitätskarten ziehen, um aus der Routine auszubrechen und den Alltag aufzulockern.",
   "start_url": "/",
   "scope": "/",

--- a/public/manifest.en.webmanifest
+++ b/public/manifest.en.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "CoupleCards",
-  "short_name": "CoupleCards",
+  "name": "Couplecards",
+  "short_name": "Couplecards",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "start_url": "/",
   "scope": "/",

--- a/public/manifest.es.webmanifest
+++ b/public/manifest.es.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "CoupleCards",
-  "short_name": "CoupleCards",
+  "name": "Couplecards",
+  "short_name": "Couplecards",
   "description": "App web autoalojada que permite a las parejas robar cartas de actividades para romper la rutina y darle chispa al día a día.",
   "start_url": "/",
   "scope": "/",

--- a/public/manifest.fr.webmanifest
+++ b/public/manifest.fr.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "CoupleCards",
-  "short_name": "CoupleCards",
+  "name": "Couplecards",
+  "short_name": "Couplecards",
   "description": "Application web auto-hébergée permettant aux couples de piocher des cartes d'activité pour casser la routine et pimenter le quotidien.",
   "start_url": "/",
   "scope": "/",

--- a/public/manifest.it.webmanifest
+++ b/public/manifest.it.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "CoupleCards",
-  "short_name": "CoupleCards",
+  "name": "Couplecards",
+  "short_name": "Couplecards",
   "description": "Web app self-hosted che permette alle coppie di pescare carte attività per spezzare la routine e ravvivare le giornate.",
   "start_url": "/",
   "scope": "/",

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v21';
+const VERSION = 'couplecards-v22';
 const SHELL = [
   '/',
   '/index.html',

--- a/public/views/draw.html
+++ b/public/views/draw.html
@@ -2,7 +2,7 @@
 <div id="screen-draw" class="screen screen-draw">
   <h1 class="draw-title">
     <img class="title-icon" src="/icons/icon.svg" alt="" aria-hidden="true" draggable="false">
-    <span data-i18n="draw.title">CoupleCards</span>
+    <span data-i18n="draw.title">Couplecards</span>
   </h1>
   <div class="draw-stage" id="draw-stage">
     <div class="bg-glow" id="bg-glow"></div>

--- a/public/views/home.html
+++ b/public/views/home.html
@@ -2,7 +2,7 @@
 <header class="app-header app-header-home">
   <h1 class="title">
     <img class="title-icon" src="/icons/icon.svg" alt="" aria-hidden="true" draggable="false">
-    <span data-i18n="app.name">CoupleCards</span>
+    <span data-i18n="app.name">Couplecards</span>
   </h1>
 </header>
 

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.0",
   "private": true,
   "type": "module",
-  "description": "CoupleCards backend — Fastify + node:sqlite",
+  "description": "Couplecards backend — Fastify + node:sqlite",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Two related polish commits.

1. **Rebrand `CoupleCards` to `Couplecards`** for a more modern feel. Touches the wordmark visible on the home, login, boot splash and draw screens, the `<title>` of every static page, the five web manifests (`name`, `short_name`), the locale catalogues (`app.name`, `draw.title`), the README, CONTRIBUTING, CREDITS, the `docs/`, and the three `deploy/*/README.md` files. The lowercase `couplecards` slug used by the npm package, the GitHub repo and the GHCR image is unchanged. Past CHANGELOG entries keep the original spelling so historical sections stay accurate.
2. **Drop a misleading PWA caveat** from `docs/i18n.md`. The note warned that switching the in-app language would not rename the home-screen icon on installed PWAs. Every locale manifest already ships the same `name` / `short_name` (the brand), so the limitation has no user-visible effect.

The Service Worker is bumped to `couplecards-v22` so installed clients refresh the HTML and manifests on next start.

## Expected behaviours

- The browser tab title, boot splash, home/login/draw wordmark, admin header and 404/500 pages all read `Couplecards`.
- The web manifest served per `Accept-Language` (5 locales) returns `Couplecards` as both `name` and `short_name`.
- After the SW upgrades to `v22`, an existing browser tab refreshes the cached HTML and manifests on the next reload.
- PWAs already installed on a device keep the icon label they captured at install time (browser-side limitation, unchanged by this PR).
- No backend, database, auth or routing change. No new dependency.

## Out of scope

- Historical CHANGELOG entries (1.4.0 and earlier) keep the `CoupleCards` spelling on purpose.
- The lowercase identifiers (`couplecards` package name, `ghcr.io/qiaeru/couplecards` image, repo slug) are untouched.
