### PR TITLE
fix: error pages CSP and demo change-password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Wordmark and brand name lowercased to **Couplecards** for a more modern feel. Applies to the home/login/boot/draw wordmark, page titles, web manifests (`name` / `short_name` across all five locales), locale catalogues (`app.name`, `draw.title`), and prose in the README, CHANGELOG header, contributing guide, credits, and `docs/`. Past CHANGELOG entries keep the original `CoupleCards` spelling. Service Worker bumped to `couplecards-v22` so the new HTML and manifests refresh on existing installs.
 
+### Fixed
+
+- Static `404.html` and `500.html` no longer rely on an inline `<script type="module">`, which the strict `script-src 'self'` CSP blocked in modern browsers. The boot logic moved to `public/js/error-page.js`, so the i18n strings now actually load and the **Reload** button on the 500 page actually triggers. Service Worker bumped to `couplecards-v23` to ship the new asset.
+
 ## [1.4.0] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Static `404.html` and `500.html` no longer rely on an inline `<script type="module">`, which the strict `script-src 'self'` CSP blocked in modern browsers. The boot logic moved to `public/js/error-page.js`, so the i18n strings now actually load and the **Reload** button on the 500 page actually triggers. Service Worker bumped to `couplecards-v23` to ship the new asset.
+- A demo visitor who tried to change their password got a misleading `400 VALIDATION_ERROR` because the `currentPassword` schema enforced an 8-character minimum and the demo password is 4 characters, so the request was rejected before the demo readonly check could run. The `currentPassword` field (and the existing login password field, refactored along the way) now accepts any non-empty value, and the route correctly returns `403 DEMO_READONLY` for the demo account. The strength policy still applies to `newPassword`.
 
 ## [1.4.0] - 2026-04-28
 

--- a/public/404.html
+++ b/public/404.html
@@ -17,10 +17,6 @@
     <p data-i18n="errors.page.404.body"></p>
     <a class="btn btn-primary" href="/" data-i18n="errors.page.404.back">Back to home</a>
   </main>
-  <script type="module">
-    // SPDX-License-Identifier: MIT
-    import { initI18n, applyI18n } from '/js/core/i18n.js';
-    initI18n().then(() => applyI18n(document)).catch(() => {});
-  </script>
+  <script type="module" src="/js/error-page.js"></script>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -17,11 +17,6 @@
     <p data-i18n="errors.page.500.body"></p>
     <button type="button" class="btn btn-primary" id="reload-btn" data-i18n="common.reload">Reload</button>
   </main>
-  <script type="module">
-    // SPDX-License-Identifier: MIT
-    import { initI18n, applyI18n } from '/js/core/i18n.js';
-    initI18n().then(() => applyI18n(document)).catch(() => {});
-    document.getElementById('reload-btn').addEventListener('click', () => location.reload());
-  </script>
+  <script type="module" src="/js/error-page.js"></script>
 </body>
 </html>

--- a/public/js/error-page.js
+++ b/public/js/error-page.js
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+// Boot script for the static error pages (404, 500). Kept as an external
+// module so the documents satisfy `script-src 'self'` without `unsafe-inline`.
+
+import { initI18n, applyI18n } from '/js/core/i18n.js';
+
+initI18n().then(() => applyI18n(document)).catch(() => {});
+
+const reloadBtn = document.getElementById('reload-btn');
+if (reloadBtn) reloadBtn.addEventListener('click', () => location.reload());

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v22';
+const VERSION = 'couplecards-v23';
 const SHELL = [
   '/',
   '/index.html',
@@ -22,6 +22,7 @@ const SHELL = [
   '/js/app.js',
   '/js/login.js',
   '/js/admin.js',
+  '/js/error-page.js',
   '/js/config.js',
   '/js/core/api.js',
   '/js/core/auth.js',

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -16,10 +16,12 @@ const usernameSchema = {
 };
 
 const passwordSchema = { type: 'string', minLength: 8, maxLength: 200 };
-// Login accepts any non-empty password length: the strength policy is enforced
-// at change-password time, and short legacy/demo passwords must still be able
-// to authenticate.
-const loginPasswordSchema = { type: 'string', minLength: 1, maxLength: 200 };
+// Login and the `currentPassword` field of change-password accept any
+// non-empty value: the strength policy is enforced on the new password, and
+// short legacy/demo passwords must still be able to authenticate (and to
+// reach the demo readonly check, which would otherwise be shadowed by a
+// schema validation error).
+const currentPasswordSchema = { type: 'string', minLength: 1, maxLength: 200 };
 
 export default async function authRoutes(app) {
   // Token used by the frontend for the x-csrf-token header on mutating requests.
@@ -58,7 +60,7 @@ export default async function authRoutes(app) {
         additionalProperties: false,
         properties: {
           username: usernameSchema,
-          password: loginPasswordSchema,
+          password: currentPasswordSchema,
         },
       },
     },
@@ -148,7 +150,7 @@ export default async function authRoutes(app) {
         required: ['currentPassword', 'newPassword'],
         additionalProperties: false,
         properties: {
-          currentPassword: passwordSchema,
+          currentPassword: currentPasswordSchema,
           newPassword: passwordSchema,
         },
       },


### PR DESCRIPTION
## Summary

Two unrelated production-only bugs that local dev never surfaced (the CSP only kicks in behind the HTTPS reverse proxies in `deploy/`, and the demo path is rarely tested for change-password).

### Error pages broken under strict CSP

`public/404.html` and `public/500.html` embedded their boot logic in an inline `<script type="module">`. With `script-src 'self'` and no `unsafe-inline` (see `server/src/plugins/helmet.js`), modern browsers block inline modules outright, so:
- the i18n strings never replaced the English fallback;
- the **Reload** button on the 500 page never received its click handler.

Boot logic moved to `public/js/error-page.js` loaded via `<script type="module" src="...">`. The file is added to the Service Worker shell list and the cache version is bumped to `couplecards-v23`.

### Demo `change-password` returned the wrong error code

The route schema applied `passwordSchema` (`minLength: 8`) to `currentPassword`. The seeded demo password is `demo` (4 chars), so a demo visitor got `400 VALIDATION_ERROR` before the handler ran. The intended response was `403 DEMO_READONLY` from the `is_demo` guard.

Fixed by lowering `currentPassword` to a non-empty string. The strength policy still applies to `newPassword`. The login `loginPasswordSchema`, already minLength-1 for the same reason, is consolidated under the shared `currentPasswordSchema`.

## Expected behaviours

- `/404.html` and `/500.html` show localised text in the browser language; the **Reload** button reloads the page.
- Existing PWA installs pick up the new shell on next reload (SW bumped to `couplecards-v23`).
- Signed in as `demo`, posting to `/api/auth/change-password` returns `403 { error: "DEMO_READONLY" }` instead of `400 VALIDATION_ERROR`.
- Login flow unchanged.
- Real users still get the full strength policy on the new password.
