### PR TITLE
chore: smarter manifest locale picker and i18n/security doc clarifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Wordmark and brand name lowercased to **Couplecards** for a more modern feel. Applies to the home/login/boot/draw wordmark, page titles, web manifests (`name` / `short_name` across all five locales), locale catalogues (`app.name`, `draw.title`), and prose in the README, CHANGELOG header, contributing guide, credits, and `docs/`. Past CHANGELOG entries keep the original `CoupleCards` spelling. Service Worker bumped to `couplecards-v22` so the new HTML and manifests refresh on existing installs.
+- The PWA manifest negotiator now parses `Accept-Language` by quality score and reads `SUPPORTED_LOCALES` from the canonical list, instead of pattern-matching the prefix of the raw header. A request like `Accept-Language: ja, fr;q=0.9` correctly serves the French manifest now (it served English before). Adding a new locale no longer requires editing `server/src/routes/manifest.js`.
 
 ## [1.4.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Documentation
+
+- `docs/i18n.md` now states explicitly that locale strings are plain text. The DOM injection paths run translated values through `escapeHtml`, so HTML tags inside a locale entry render literally and contributors should structure the DOM around the text rather than embed markup in the catalogue.
+- `docs/security.md` calls out that authentication attempts are not written to a historical journal: only the per-user `failed_attempts` counter exists and it is reset on successful sign-in. Operators who need an audit trail can rely on the Pino access logs or a reverse proxy.
+
 ### Changed
 
 - Wordmark and brand name lowercased to **Couplecards** for a more modern feel. Applies to the home/login/boot/draw wordmark, page titles, web manifests (`name` / `short_name` across all five locales), locale catalogues (`app.name`, `draw.title`), and prose in the README, CHANGELOG header, contributing guide, credits, and `docs/`. Past CHANGELOG entries keep the original `CoupleCards` spelling. Service Worker bumped to `couplecards-v22` so the new HTML and manifests refresh on existing installs.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -18,6 +18,8 @@ User-visible text lives in flat JSON files with dotted keys such as `login.title
 
 Placeholders use double curly braces. For example, `"home.title": "Welcome, {{a}} and {{b}}!"` is called with `t('home.title', { a, b })` and the helper interpolates the values. For plurals, declare the CLDR variants on the same root key: at minimum `key.one` and `key.other`, and optionally `zero`, `two`, `few` and `many`. Call `tn(key, count, params)` and the helper picks the right variant through `Intl.PluralRules`.
 
+**Locale strings are plain text, never HTML.** Code paths that inject translated text into the DOM go through `escapeHtml(t(...))` or use `textContent`, both of which neutralise tags. A traduction like `"errors.deck.empty": "No <strong>cards</strong> available"` will render the angle brackets literally. If you need a word emphasised inside a sentence, structure the DOM around the translated text rather than embedding markup in the locale value (split the sentence into two keys and wrap the middle one in a `<strong>` element, or use placeholder substitution and inject a span node from the calling code). This keeps translators from accidentally introducing XSS surface and keeps the locale catalogue language-neutral.
+
 Static HTML carries a fallback value inside the element plus a `data-i18n="key"` attribute. The fallback must match the English locale string exactly, because it is the text shown before JavaScript boots. A quick sanity check runs from the repo root:
 
 ```bash

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -47,7 +47,7 @@ The server negotiates the manifest based on the request's `Accept-Language` head
 
 1. Copy [`public/manifest.en.webmanifest`](../public/manifest.en.webmanifest) to `public/manifest.<code>.webmanifest`.
 2. Translate the `name`, `short_name` and `description` fields.
-3. Extend the negotiation inside [`server/src/routes/manifest.js`](../server/src/routes/manifest.js) so the new code is matched against `Accept-Language`.
+3. Nothing to wire up server-side. [`server/src/routes/manifest.js`](../server/src/routes/manifest.js) reads `SUPPORTED_LOCALES` and parses the `Accept-Language` header by quality score, so the new code starts being negotiated automatically as soon as Step 3 below adds it to the canonical list.
 
 ### Step 3. Card translations
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -71,6 +71,7 @@ The optional `demo` account, enabled with `ENABLE_DEMO_ACCOUNT=1`, is a delibera
 
 - Fastify's Pino logger runs at `info` in production.
 - Password fields (`req.body.password`, `req.body.newPassword`, `req.body.currentPassword`) and the generated initial password are redacted from every log line.
+- The login route increments a per-user `failed_attempts` counter (used for lockout) but does not write a historical journal of authentication attempts. After a successful sign-in the counter is reset, so a compromised account leaves no in-app trace of when or from where the attacker connected. This is an explicit trade-off for the small-scale, two-person threat model the app targets. Operators who need an audit trail can mine the Pino access logs (timestamps, IP via Fastify's `request.ip`, `req.url`) shipped on stdout, or front the app with a reverse proxy that records its own access log.
 
 ## Vulnerability disclosure
 

--- a/server/src/routes/manifest.js
+++ b/server/src/routes/manifest.js
@@ -4,15 +4,26 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { config } from '../config.js';
+import { SUPPORTED_LOCALES, FALLBACK_LOCALE } from '../lib/locales.js';
 
 function pickLocale(acceptLanguage) {
-  if (!acceptLanguage) return 'en';
-  const normalized = acceptLanguage.toLowerCase();
-  if (normalized.startsWith('fr')) return 'fr';
-  if (normalized.startsWith('de')) return 'de';
-  if (normalized.startsWith('it')) return 'it';
-  if (normalized.startsWith('es')) return 'es';
-  return 'en';
+  if (!acceptLanguage) return FALLBACK_LOCALE;
+  const tags = acceptLanguage.split(',').map((entry) => {
+    const [tag, ...params] = entry.trim().split(';');
+    let q = 1;
+    for (const p of params) {
+      const m = p.trim().match(/^q=(\d+(?:\.\d+)?)$/i);
+      if (m) q = Number(m[1]);
+    }
+    return { tag: tag.toLowerCase(), q };
+  }).filter((entry) => entry.tag && entry.q > 0)
+    .sort((a, b) => b.q - a.q);
+
+  for (const { tag } of tags) {
+    const primary = tag.split('-')[0];
+    if (SUPPORTED_LOCALES.includes(primary)) return primary;
+  }
+  return FALLBACK_LOCALE;
 }
 
 export default async function manifestRoutes(app) {


### PR DESCRIPTION
## Summary

Polish pass surfacing two convention notes the code already honours, plus a small refactor of the PWA manifest negotiator.

### Manifest locale picker

The previous picker matched the raw `Accept-Language` header prefix against five hardcoded codes. It got common cases right but mishandled `Accept-Language: ja, fr;q=0.9` (returns English when French is the clear runner-up), and adding a new locale required editing the function.

The new picker parses the header into `{tag, q}` pairs sorted by descending quality, strips each tag to its primary subtag, and returns the first one that appears in the canonical `SUPPORTED_LOCALES`. The corresponding `i18n.md` step that asked contributors to extend the negotiation is now obsolete.

### Documentation

- `docs/i18n.md` now states explicitly that locale strings are plain text and that DOM injection runs them through `escapeHtml`, so embedded HTML tags render literally.
- `docs/security.md` calls out that authentication attempts are not written to a historical journal (only the `failed_attempts` counter exists, reset on successful sign-in). Operators who need an audit trail can mine the Pino access logs or front the app with a reverse proxy.

## Expected behaviours

- A request with `Accept-Language: ja, fr;q=0.9` returns `manifest.fr.webmanifest`.
- A request with no header, or with no supported language anywhere in the list, returns `manifest.en.webmanifest`.
- Existing supported locales (`en`, `fr`, `de`, `it`, `es`) are still picked correctly from any plausible browser-emitted header.
- No code changes for translators or contributors; the docs only formalise existing behaviour.
