### PR TITLE
fix: reject admin cookie on player-only API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Static `404.html` and `500.html` no longer rely on an inline `<script type="module">`, which the strict `script-src 'self'` CSP blocked in modern browsers. The boot logic moved to `public/js/error-page.js`, so the i18n strings now actually load and the **Reload** button on the 500 page actually triggers. Service Worker bumped to `couplecards-v23` to ship the new asset.
 - A demo visitor who tried to change their password got a misleading `400 VALIDATION_ERROR` because the `currentPassword` schema enforced an 8-character minimum and the demo password is 4 characters, so the request was rejected before the demo readonly check could run. The `currentPassword` field (and the existing login password field, refactored along the way) now accepts any non-empty value, and the route correctly returns `403 DEMO_READONLY` for the demo account. The strength policy still applies to `newPassword`.
 
+### Security
+
+- Player-only API endpoints (`/api/state`, `/api/state/reset`, `/api/bans*`, `/api/history`) now reject the admin role with `403 FORBIDDEN`. The admin UI lands on `/admin.html` and never plays cards, but the routes were previously gated only by `requireSession`, which left an admin cookie able to script against its own bans and history through curl or DevTools. A new `requireUser` guard in `server/src/lib/auth.js` consolidates the session check, the password-change gate and the non-admin check.
+
 ## [1.4.0] - 2026-04-28
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,6 +102,8 @@ The procedure to add a third language is documented end-to-end in [i18n.md](./i1
 
 ## Backend routes
 
+Four guard levels are referenced below: **public** (no auth needed), **session** (any signed-in account), **user** (signed-in non-admin account, used for the player-only state and history endpoints) and **admin**.
+
 | Method | Path | Auth | Notes |
 | --- | --- | --- | --- |
 | `GET` | `/api/health` | public | Liveness probe |
@@ -117,10 +119,10 @@ The procedure to add a third language is documented end-to-end in [i18n.md](./i1
 | `GET` | `/api/admin/cards/export` | admin | Downloads a ZIP with one `cards.<locale>.json` per supported locale, pretty-printed |
 | `POST` | `/api/admin/cards/sync` | admin | Reads every `cards.<locale>.json` under `data/` and applies them together (mirror or upsert) |
 | `POST` | `/api/admin/cards/import` | admin | Applies a deck uploaded in the request body (multilingual shape) |
-| `GET` | `/api/state` | session | Returns `{ banned, history }` |
-| `POST` | `/api/state/reset` | session | Wipes the caller's bans and history in a single transaction. Rejected with 403 for demo accounts |
-| `POST`, `DELETE` | `/api/bans[/:cardId]` | session | Idempotent |
-| `POST` | `/api/history` | session | Batch endpoint, idempotent on `clientUuid` |
+| `GET` | `/api/state` | user | Returns `{ banned, history }` |
+| `POST` | `/api/state/reset` | user | Wipes the caller's bans and history in a single transaction. Rejected with 403 for demo accounts |
+| `POST`, `DELETE` | `/api/bans[/:cardId]` | user | Idempotent |
+| `POST` | `/api/history` | user | Batch endpoint, idempotent on `clientUuid` |
 | `GET`, `POST`, `PATCH`, `DELETE` | `/api/admin/users[/:id]` | admin | Full user CRUD plus unlock and reset-password |
 | `GET` | `/manifest.webmanifest` | public | Negotiated on `Accept-Language` |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,6 +8,7 @@ Audience: admins who self-host the app and want a clear picture of the measures 
 - The password policy is enforced on the server, with the client mirroring it for live feedback. The hard rules are a minimum length of 12 characters, at least one uppercase letter, one lowercase letter, one digit and one special character, no whitespace, and no inclusion of the username. Each password must also reach a zxcvbn score of 4 for the admin account and 3 for a regular user, with one dictionary loaded per supported locale (English, French, German, Italian, Spanish).
 - Initial user passwords are generated with `crypto.randomBytes` and enforced character classes. The admin sees the value once; only the hash is stored.
 - A user account with a pending password change cannot reach any protected endpoint until the password has been updated.
+- Role separation is enforced at the API layer, not just in the UI. The admin account always lands on `/admin.html` and never plays cards, so the player-only endpoints (`/api/state`, `/api/state/reset`, `/api/bans*`, `/api/history`) reject any cookie carrying the `admin` role with `403 FORBIDDEN`. Conversely, every `/api/cards` mutation and every `/api/admin/*` route requires the admin role.
 
 ## Session management
 

--- a/server/src/lib/auth.js
+++ b/server/src/lib/auth.js
@@ -52,6 +52,19 @@ export async function requireAdmin(request, reply) {
   await enforcePasswordChange(request, reply);
 }
 
+// Player-only routes: an authenticated session is required and the admin role
+// is rejected. The admin UI lands on /admin.html and never plays cards, so the
+// /api/state, /api/bans, /api/history and /api/state/reset endpoints have no
+// reason to be reachable with an admin cookie.
+export async function requireUser(request, reply) {
+  await requireSession(request, reply);
+  if (reply.sent) return;
+  if (request.currentUser.role === 'admin') {
+    return reply.code(403).send({ error: 'FORBIDDEN' });
+  }
+  await enforcePasswordChange(request, reply);
+}
+
 // Must stay async: Fastify 5 silently stalls routes that mix sync and async
 // preHandlers in the same chain. /api/auth/change-password calls requireSession
 // directly so it can run even with must_change_password = 1.

--- a/server/src/routes/sync.js
+++ b/server/src/routes/sync.js
@@ -3,7 +3,7 @@
 // Mutations are idempotent so the frontend outbox can safely replay them.
 
 import { getDb, transaction } from '../db/index.js';
-import { requireSession, enforcePasswordChange } from '../lib/auth.js';
+import { requireUser } from '../lib/auth.js';
 
 const HISTORY_CAP = 500;
 
@@ -12,11 +12,7 @@ const cardIdSchema = { type: 'string', pattern: '^[a-z0-9-]{1,64}$' };
 export default async function syncRoutes(app) {
   // Single consolidated preHandler. See server/src/lib/auth.js for the
   // Fastify 5 pitfall (mixed sync/async preHandlers stall silently).
-  app.addHook('preHandler', async (request, reply) => {
-    await requireSession(request, reply);
-    if (reply.sent) return;
-    await enforcePasswordChange(request, reply);
-  });
+  app.addHook('preHandler', requireUser);
 
   app.get('/state', async (request) => {
     const db = getDb();


### PR DESCRIPTION
## Summary

The admin UI was already locked down: `public/js/app.js` redirects to `/admin.html` at boot and `public/js/login.js` does the same after a successful sign-in, so an admin browsing the SPA never reaches the draw screen. The API was a different story: `/api/state`, `/api/state/reset`, `/api/bans`, `/api/bans/:cardId` and `/api/history` were gated only by `requireSession`. An admin holding a valid cookie could therefore script against those endpoints through curl, DevTools or a custom client and pollute its own bans/history rows.

No data leak (each row is keyed on `user_id`), but a least-privilege gap and an avoidable mismatch between the UI policy and the API contract.

## What changed

- New `requireUser` guard in `server/src/lib/auth.js`: runs `requireSession`, rejects the `admin` role with `403 FORBIDDEN`, then enforces the password-change gate. Mirrors the shape of the existing `requireAdmin`.
- `server/src/routes/sync.js` swaps its consolidated preHandler hook from `requireSession + enforcePasswordChange` to the new `requireUser`. Net: the file gets shorter.
- `docs/architecture.md` introduces a fourth guard level (**user**) and tags the relevant rows in the route table accordingly.
- `docs/security.md` documents the rule under Authentication.

`GET /api/cards` is intentionally untouched: the admin Cards tab needs to read the deck. Mutations on `/api/cards` and every `/api/admin/*` route already used `requireAdmin`.

The shared demo account is `role = user`, so the demo flow is unaffected.

## Expected behaviours

- Signed in as the seeded admin, posting `GET /api/state` (or `POST /api/bans`, `POST /api/history`, `POST /api/state/reset`) returns `403 { error: "FORBIDDEN" }`.
- Signed in as a regular user, every player endpoint behaves exactly as before.
- Signed in as `demo`, every player endpoint behaves exactly as before (and `/api/state/reset` still returns `403 DEMO_READONLY`).
- Admin Cards tab still loads the deck through `GET /api/cards` and edits go through the existing admin-gated mutations.
- The SPA redirect for admin sessions (`location.replace('/admin.html')`) is unchanged; the API enforcement is purely defence-in-depth behind it.
