### PR TITLE
fix(ui): tighten piles and revealed card on short phone viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Home screen and revealed card now fit on short phone viewports (around 640 to 720px tall) without scrolling. The two stacked piles shrink and tighten their gap on small heights, and on the draw screen the card itself, its typography and the action buttons step down so the description stays readable above the **Bannir / Remettre / Nouvelle carte** row instead of being covered by it. Service Worker bumped to `couplecards-v24` to ship the new CSS.
+
 ## [1.4.1] - 2026-04-29
 
 ### Changed

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -893,6 +893,43 @@
   to   { opacity: 1; transform: translateY(0); }
 }
 
+/* Short viewports: shrink the revealed card and its typography so the
+   description stays clear of the action buttons pinned to the bottom on
+   small phones. */
+@media (max-height: 740px) {
+  .draw-stage {
+    width: min(300px, 80vw);
+    height: min(420px, 64vh);
+  }
+  .card-frame { inset: 10px; padding: 14px 16px 12px; }
+  .card-pile-label { margin-bottom: 8px; font-size: 0.62rem; letter-spacing: 0.28em; }
+  .card-art { margin-bottom: 10px; }
+  .card-art-emoji { font-size: 4.4rem; }
+  .card-title { font-size: 1.18rem; margin-bottom: 4px; }
+  .card-divider { margin: 2px 0 6px; height: 12px; }
+  .card-description { font-size: 0.92rem; line-height: 1.4; }
+  .card-footer-mark { padding-top: 6px; font-size: 0.7rem; }
+  .draw-actions {
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 12px);
+    gap: 6px;
+  }
+  .draw-actions .btn {
+    padding: 9px 12px;
+    font-size: 0.86rem;
+    min-height: 40px;
+  }
+  .draw-title { top: calc(env(safe-area-inset-top, 0px) + 12px); }
+}
+@media (max-height: 620px) {
+  .draw-stage {
+    width: min(260px, 72vw);
+    height: min(360px, 60vh);
+  }
+  .card-art-emoji { font-size: 3.6rem; }
+  .card-title { font-size: 1.05rem; }
+  .card-description { font-size: 0.86rem; line-height: 1.35; }
+}
+
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .card-flip.enter { animation: card-enter-rm 0.3s ease forwards; }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -419,6 +419,24 @@ body::before {
     max-width: 500px;
   }
 }
+/* Short phone viewports: shrink the stacked piles so the home screen fits
+   without scrolling on devices around 640-720px tall. */
+@media (max-width: 539px) and (max-height: 720px) {
+  #screen-home { gap: 12px; }
+  .piles {
+    max-width: 152px;
+    gap: 12px;
+    padding: 0;
+  }
+  .pile {
+    min-height: 110px;
+    padding: 12px 10px 16px;
+  }
+  .pile-emoji { font-size: 1.9rem; }
+  .pile-name { font-size: 0.95rem; }
+  .pile-count { font-size: 0.72rem; padding: 3px 10px; }
+  .pile-low-hint { margin-top: 4px; font-size: 0.65rem; }
+}
 
 /* Piles = empilements de cartes */
 .pile {

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v23';
+const VERSION = 'couplecards-v24';
 const SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

Reports from users on small phones: the home screen forced a scroll, and on the draw screen the revealed card was so tall that the **Bannir / Remettre / Nouvelle carte** buttons covered the description.

Two height-based media queries fix both, with no impact on desktop or tablet rendering:

- `public/css/style.css` — `@media (max-width: 539px) and (max-height: 720px)` shrinks the stacked piles (max-width 186 → 152px, gap 24 → 12px), tightens padding and steps the emoji / pile name / count down a notch.
- `public/css/cards.css` — `@media (max-height: 740px)` shrinks `.draw-stage` (`min(300px, 80vw) × min(420px, 64vh)`), tightens the card frame, scales down title / description / footer typography, and compacts the action buttons (40px tall, 0.86rem). A second tier at `(max-height: 620px)` handles very short viewports.
- `public/sw.js` — VERSION bumped to `couplecards-v24` so existing installs pull the new CSS.

## Expected behaviour

- On a phone around 375×667 (iPhone SE) or 360×640, the home screen shows both piles fully without scrolling.
- On the same screens the revealed card no longer extends behind the action row; the description stays clear of the buttons.
- On wider or taller viewports (tablets, desktop, modern phones in landscape) nothing changes.
