### PR TITLE
fix: admin delete toast and settings double-submit / innerHTML cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `POST /api/auth/preferences` accepted only `fr` and `en` because of a hardcoded enum, so users on de, it or es could not persist their language choice to the server (the locale still applied client-side). The schema now reads from the canonical `SUPPORTED_LOCALES` list and accepts every shipped locale.
 - Boot error pages (shown when the SPA or admin shell fails to start) now display localised strings instead of hardcoded English. Three new keys added to all five locale files. If the failure happens before the catalogue loads, English is used as fallback.
 - Admin language picker rebuilds its options through `createElement` instead of an `innerHTML` string, aligning with the rest of the admin UI's CSP-defensive DOM construction. Service Worker bumped to `couplecards-v26`.
+- Deleting an admin user showed a "Copied" toast instead of a deletion confirmation (copy-paste leftover from the clipboard handler). A new `admin.users.delete.toast` key is shipped in the five locale catalogues and the right one is now displayed.
+- The user-facing language picker in Settings now builds its `<option>` list with `createElement` instead of an `innerHTML` template string, matching the admin picker fix from the previous patch.
+- Reset Data button in Settings now disables itself during the request, so a double-tap can no longer fire two `POST /api/state/reset` calls in a row. Service Worker bumped to `couplecards-v27`.
 
 ## [1.4.1] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,25 +8,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Home screen and revealed card now fit on short phone viewports (around 640 to 720px tall) without scrolling. The two stacked piles shrink and tighten their gap on small heights, and on the draw screen the card itself, its typography and the action buttons step down so the description stays readable above the action row. Service Worker bumped to `couplecards-v24` to ship the new CSS.
-- Bottom navigation no longer mangles long localised labels on narrow phones. Two-line entries ("Bannissements", "Verbannte Karten", "Cartas vetadas", "Carte bannite", "Impostazioni") are now centered under their icon, can wrap mid-word when needed, and step down to a smaller font under 380px wide. Service Worker bumped to `couplecards-v25`.
+- Home screen and revealed card now fit on short phone viewports (around 640 to 720px tall) without scrolling. The two stacked piles shrink and tighten their gap on small heights, and on the draw screen the card itself, its typography and the action buttons step down so the description stays readable above the action row.
+- Bottom navigation no longer mangles long localised labels on narrow phones. Two-line entries ("Bannissements", "Verbannte Karten", "Cartas vetadas", "Carte bannite", "Impostazioni") are now centered under their icon, can wrap mid-word when needed, and step down to a smaller font under 380px wide.
 - `POST /api/auth/preferences` accepted only `fr` and `en` because of a hardcoded enum, so users on de, it or es could not persist their language choice to the server (the locale still applied client-side). The schema now reads from the canonical `SUPPORTED_LOCALES` list and accepts every shipped locale.
 - Boot error pages (shown when the SPA or admin shell fails to start) now display localised strings instead of hardcoded English. Three new keys added to all five locale files. If the failure happens before the catalogue loads, English is used as fallback.
-- Admin language picker rebuilds its options through `createElement` instead of an `innerHTML` string, aligning with the rest of the admin UI's CSP-defensive DOM construction. Service Worker bumped to `couplecards-v26`.
+- Admin language picker rebuilds its options through `createElement` instead of an `innerHTML` string, aligning with the rest of the admin UI's CSP-defensive DOM construction.
 - Deleting an admin user showed a "Copied" toast instead of a deletion confirmation (copy-paste leftover from the clipboard handler). A new `admin.users.delete.toast` key is shipped in the five locale catalogues and the right one is now displayed.
 - The user-facing language picker in Settings now builds its `<option>` list with `createElement` instead of an `innerHTML` template string, matching the admin picker fix from the previous patch.
-- Reset Data button in Settings now disables itself during the request, so a double-tap can no longer fire two `POST /api/state/reset` calls in a row. Service Worker bumped to `couplecards-v27`.
+- Reset Data button in Settings now disables itself during the request, so a double-tap can no longer fire two `POST /api/state/reset` calls in a row.
 
 ## [1.4.1] - 2026-04-29
 
 ### Changed
 
-- Wordmark and brand name lowercased to **Couplecards** across the UI, page titles, all five web manifests, locale catalogues and the project docs. Past CHANGELOG entries keep the original `CoupleCards` spelling. Service Worker bumped to `couplecards-v22` to refresh the new HTML and manifests on existing installs.
+- Wordmark and brand name lowercased to **Couplecards** across the UI, page titles, all five web manifests, locale catalogues and the project docs. Past CHANGELOG entries keep the original `CoupleCards` spelling.
 - The PWA manifest negotiator now parses `Accept-Language` by quality score and reads `SUPPORTED_LOCALES` from the canonical list. A request like `Accept-Language: ja, fr;q=0.9` correctly serves the French manifest (it served English before), and adding a new locale no longer requires editing `server/src/routes/manifest.js`.
 
 ### Fixed
 
-- Static `404.html` and `500.html` no longer rely on an inline `<script type="module">`, which the strict `script-src 'self'` CSP blocked in modern browsers. The boot logic moved to `public/js/error-page.js`, so the i18n strings now actually load and the **Reload** button on the 500 page actually triggers. Service Worker bumped to `couplecards-v23` to ship the new asset.
+- Static `404.html` and `500.html` no longer rely on an inline `<script type="module">`, which the strict `script-src 'self'` CSP blocked in modern browsers. The boot logic moved to `public/js/error-page.js`, so the i18n strings now actually load and the **Reload** button on the 500 page actually triggers.
 - A demo visitor who tried to change their password got a misleading `400 VALIDATION_ERROR` because the `currentPassword` schema enforced an 8-character minimum while the demo password is 4 characters. The field now accepts any non-empty value and the route correctly returns `403 DEMO_READONLY`. The strength policy still applies to `newPassword`.
 
 ### Security
@@ -59,7 +59,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Wordmark glow softened, font-size shrunk ~10%, and the primary blur radius now matches between the wordmark text and the heart icon next to it.
 - Bright accent colour applied to the selected and hovered option of every `<select>` dropdown so the highlight is clearly visible (was previously a muted dark-pink barely distinguishable from the option background).
 - README and screenshots refreshed to reflect the five-locale lineup.
-- Service Worker bumped to `couplecards-v19` to invalidate caches holding the old `sync.js`, `deck-sync.js`, and the previous locale catalogues.
 
 ### Fixed
 
@@ -77,7 +76,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Add a magnifying-glass icon inside the Users and Cards search inputs in the admin panel, so the affordance reads as a search box rather than a generic text input.
 - Tighten the admin panels: remove the redundant `<h2>` subtitles ("Users", "Cards", "Settings") that duplicated the active tab label, drop the now-orphaned `.admin-panel h2` style, and normalise every gap inside `.admin-panel` to 14 px. The previous `.list` internal padding and the manual `margin-top` on the "Add a card" button were compensating for each other; both are gone.
 - Login form: hide the empty error region (`.auth-error:empty`) so the gap between the password input and the "Sign in" button is no longer doubled by an invisible flex item.
-- Service Worker bumped to `couplecards-v15` and the precache shell list updated to point at the Fraunces WOFF2 files (variable + italic across Latin, Latin Extended and Vietnamese) instead of the dropped Literata subsets.
 
 ### Fixed
 

--- a/public/js/features/admin/users.js
+++ b/public/js/features/admin/users.js
@@ -129,7 +129,7 @@ async function deleteUser(id, username) {
   });
   if (!ok) return;
   await request(`/api/admin/users/${id}`, { method: 'DELETE' });
-  toast(t('common.copied'));
+  toast(t('admin.users.delete.toast'));
   await renderUsers();
 }
 

--- a/public/js/features/settings/settings.js
+++ b/public/js/features/settings/settings.js
@@ -16,11 +16,15 @@ export async function mount() {
   if (langSelect) {
     // Sort by native language name so the picker order is stable across UI
     // locales and predictable for users (Deutsch, English, Español, ...).
-    langSelect.innerHTML = supportedLocales()
+    const options = supportedLocales()
       .map((l) => ({ code: l, label: t(`settings.language.${l}`) }))
-      .sort((a, b) => a.label.localeCompare(b.label))
-      .map(({ code, label }) => `<option value="${code}">${label}</option>`)
-      .join('');
+      .sort((a, b) => a.label.localeCompare(b.label));
+    langSelect.replaceChildren(...options.map(({ code, label }) => {
+      const opt = document.createElement('option');
+      opt.value = code;
+      opt.textContent = label;
+      return opt;
+    }));
     langSelect.value = getLocale();
     langSelect.addEventListener('change', async () => {
       await setLocale(langSelect.value);
@@ -69,11 +73,14 @@ export async function mount() {
         danger: true,
       });
       if (!ok) return;
+      resetBtn.disabled = true;
       try {
         await resetUserData();
         toast(t('settings.resetData.toast'));
       } catch {
         toast(t('errors.generic'));
+      } finally {
+        resetBtn.disabled = false;
       }
     });
   }

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -125,6 +125,7 @@
   "admin.users.reset.body": "Es wird ein neues Einmalpasswort erzeugt. Der Benutzer muss es bei der nächsten Anmeldung ändern.",
   "admin.users.delete.confirm": "{{username}} löschen?",
   "admin.users.delete.body": "Verlauf und verbannte Karten werden ebenfalls gelöscht.",
+  "admin.users.delete.toast": "Benutzer gelöscht",
   "admin.users.unlock": "Entsperren",
   "admin.users.locked": "Gesperrt",
   "admin.users.mustChange": "Passwortwechsel erforderlich",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -125,6 +125,7 @@
   "admin.users.reset.body": "A new one-time password will be generated. The user will have to change it on next sign-in.",
   "admin.users.delete.confirm": "Delete {{username}}?",
   "admin.users.delete.body": "Their history and bans will also be deleted.",
+  "admin.users.delete.toast": "User deleted",
   "admin.users.unlock": "Unlock",
   "admin.users.locked": "Locked",
   "admin.users.mustChange": "Password change required",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -125,6 +125,7 @@
   "admin.users.reset.body": "Se generará una contraseña nueva de un solo uso. El usuario deberá cambiarla en su próximo inicio de sesión.",
   "admin.users.delete.confirm": "¿Eliminar a {{username}}?",
   "admin.users.delete.body": "También se eliminarán su historial y sus cartas vetadas.",
+  "admin.users.delete.toast": "Usuario eliminado",
   "admin.users.unlock": "Desbloquear",
   "admin.users.locked": "Bloqueado",
   "admin.users.mustChange": "Cambio de contraseña obligatorio",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -125,6 +125,7 @@
   "admin.users.reset.body": "Un nouveau mot de passe à usage unique sera généré. L'utilisateur devra le modifier à sa prochaine connexion.",
   "admin.users.delete.confirm": "Supprimer {{username}} ?",
   "admin.users.delete.body": "Son historique et ses bannissements seront également supprimés.",
+  "admin.users.delete.toast": "Utilisateur supprimé",
   "admin.users.unlock": "Déverrouiller",
   "admin.users.locked": "Verrouillé",
   "admin.users.mustChange": "Changement de mot de passe requis",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -125,6 +125,7 @@
   "admin.users.reset.body": "Verrà generata una nuova password monouso. L'utente dovrà cambiarla al prossimo accesso.",
   "admin.users.delete.confirm": "Eliminare {{username}}?",
   "admin.users.delete.body": "Verranno eliminati anche cronologia e carte bannate.",
+  "admin.users.delete.toast": "Utente eliminato",
   "admin.users.unlock": "Sblocca",
   "admin.users.locked": "Bloccato",
   "admin.users.mustChange": "Cambio password obbligatorio",

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v26';
+const VERSION = 'couplecards-v27';
 const SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

Two concerns shipped on the same branch — both are small admin/settings polish or CHANGELOG hygiene.

### 1. `fix: admin delete toast and settings double-submit / innerHTML cleanup` (d1f0c8a)

Three small defects surfaced by a pre-1.4.2 audit pass:

- **`admin/users.js:132`**: deleting a user showed `t('common.copied')` ("Copied"), a copy-paste leftover from the clipboard handler. A dedicated `admin.users.delete.toast` key now ships in all five locale catalogues and is used by the delete handler.
- **`settings/settings.js:19-23`**: the user-facing language picker still built its `<option>` list with an `innerHTML` template string. Switched to `createElement` so it matches the admin picker fix from PR #34 and the rest of the codebase's CSP-defensive DOM construction.
- **`settings/settings.js:63-78`**: the Reset Data button did not disable itself during the async `POST /api/state/reset` call, so a double-tap could fire two reset requests in a row. Disable + `finally`-restore.

### 2. `docs: stop tracking Service Worker bumps in CHANGELOG` (42aec1c)

The Service Worker `VERSION` constant in `public/sw.js` is an operational artefact for cache invalidation, not a user-visible change. Mentioning it in every entry that touched a static asset added noise without adding information. Strip the trailing "Service Worker bumped to ..." sentence from every existing entry (including released sections 1.4.1, 1.4.0, 1.3.0), drop the two standalone bullets that contained nothing else, and stop adding the line going forward.

## Expected behaviour

- Deleting a user shows the localised "User deleted" toast instead of "Copied".
- The Settings language picker behaves identically to before.
- Tapping Reset Data twice only sends one POST.
- All five locale catalogues remain at parity (220 keys each).
- CHANGELOG is shorter and free of operational noise.