### PR TITLE
chore(release): cut version 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-05-01
+
 ### Fixed
 
-- Home screen and revealed card now fit on short phone viewports (around 640 to 720px tall) without scrolling. The two stacked piles shrink and tighten their gap on small heights, and on the draw screen the card itself, its typography and the action buttons step down so the description stays readable above the action row.
+- Home screen and revealed card now fit on short phone viewports (around 640 to 720px tall) without scrolling. The stacked piles shrink and tighten their gap on small heights, and on the draw screen the card and the action buttons step down so the description stays readable above them.
 - Bottom navigation no longer mangles long localised labels on narrow phones. Two-line entries ("Bannissements", "Verbannte Karten", "Cartas vetadas", "Carte bannite", "Impostazioni") are now centered under their icon, can wrap mid-word when needed, and step down to a smaller font under 380px wide.
 - `POST /api/auth/preferences` accepted only `fr` and `en` because of a hardcoded enum, so users on de, it or es could not persist their language choice to the server (the locale still applied client-side). The schema now reads from the canonical `SUPPORTED_LOCALES` list and accepts every shipped locale.
-- Boot error pages (shown when the SPA or admin shell fails to start) now display localised strings instead of hardcoded English. Three new keys added to all five locale files. If the failure happens before the catalogue loads, English is used as fallback.
-- Admin language picker rebuilds its options through `createElement` instead of an `innerHTML` string, aligning with the rest of the admin UI's CSP-defensive DOM construction.
-- Deleting an admin user showed a "Copied" toast instead of a deletion confirmation (copy-paste leftover from the clipboard handler). A new `admin.users.delete.toast` key is shipped in the five locale catalogues and the right one is now displayed.
-- The user-facing language picker in Settings now builds its `<option>` list with `createElement` instead of an `innerHTML` template string, matching the admin picker fix from the previous patch.
 - Reset Data button in Settings now disables itself during the request, so a double-tap can no longer fire two `POST /api/state/reset` calls in a row.
+- Deleting an admin user showed a "Copied" toast instead of a deletion confirmation (copy-paste leftover from the clipboard handler). A new `admin.users.delete.toast` key now ships in the five locale catalogues and is displayed instead.
+- Boot error pages (shown when the SPA or admin shell fails to start) now display localised strings instead of hardcoded English, falling back to English only when the catalogue itself never loaded.
+- Both language pickers (Settings and admin) build their `<option>` lists with `createElement` instead of `innerHTML` template strings, matching the rest of the codebase's CSP-defensive DOM construction.
 
 ## [1.4.1] - 2026-04-29
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@fastify/csrf-protection": "^7.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "type": "module",
   "description": "Couplecards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

Cuts patch release **1.4.2** (semver patch: bug fixes only since 1.4.1).

- `package.json` and `server/package.json` bumped to `1.4.2`.
- `package-lock.json` and `server/package-lock.json` bumped at both the top object and `packages.""` (no dependency changes).
- `CHANGELOG.md` `[Unreleased]` promoted to `[1.4.2] - 2026-05-01`, bullets reordered most-user-visible to most-technical, and the two redundant language-picker entries (Settings + admin `createElement`) collapsed into one. A fresh empty `[Unreleased]` section is added on top.

Release contents (all `Fixed`):

- Home screen and revealed card now fit short phone viewports without scrolling.
- Bottom navigation no longer mangles long localised labels on narrow phones.
- `POST /api/auth/preferences` now accepts every shipped locale (was hardcoded to `fr`/`en`).
- Reset Data button disables during the request to block double-submit.
- Deleting an admin user now shows the right toast.
- Boot error pages are localised.
- Both language pickers built via `createElement` instead of `innerHTML`.

## After merge

- I tag `v1.4.2` from `main` and walk the owner through publishing the GitHub Release.
- The Docker image publish is triggered automatically by the Release.