### PR TITLE
chore(release): cut version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-05-03
+
 ### Added
 
 - New **Collection** screen showing every card in the deck as a grid: drawn cards reveal their full design, banned cards carry a red cross, undiscovered cards stay as dark silhouettes with a "?". A `X / Y cards discovered` counter (with a slot-machine cipher reveal), filters by pile plus a Rare-only filter, and a pulse outline that follows the most recently drawn card so it is easy to locate after a draw. Rare silhouettes wear a soft breathing rainbow halo so they stand out without revealing the title.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/csrf-protection": "^7.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "description": "Couplecards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

- Bumps version to **1.5.0** in `package.json`, `server/package.json` and both `package-lock.json` files.
- Renames the `[Unreleased]` block in `CHANGELOG.md` to `[1.5.0] - 2026-05-03` and opens a fresh empty `[Unreleased]` section above it.

Minor bump per semver: ships the new Collection screen, the offline / pending-sync banner and the per-route scroll restoration.

## Test plan

- [ ] CI build is green.