### PR TITLE
fix(security): scope upgrade-insecure-requests CSP to HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Plain-HTTP LAN deployments no longer break with `ERR_SSL_PROTOCOL_ERROR` on every asset. The `upgrade-insecure-requests` CSP directive is now emitted only when the app knows it is served over HTTPS, instead of being added unconditionally by the security defaults.
+
 ## [1.5.0] - 2026-05-03
 
 ### Added

--- a/docs/security.md
+++ b/docs/security.md
@@ -35,7 +35,7 @@ Audience: admins who self-host the app and want a clear picture of the measures 
 When running behind any HTTPS variant in `deploy/`, the server emits the following headers:
 
 - `Strict-Transport-Security: max-age=63072000; includeSubDomains`.
-- `Content-Security-Policy: default-src 'self'; ...; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'`. The policy uses neither `unsafe-inline` nor `unsafe-eval`.
+- `Content-Security-Policy: default-src 'self'; ...; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'`. The policy uses neither `unsafe-inline` nor `unsafe-eval`. The `upgrade-insecure-requests` directive is appended only when the server is configured for HTTPS (`COOKIE_SECURE=1` or one of the HTTPS deploy variants); a plain-HTTP LAN deployment omits it so assets are not rewritten to a scheme the server cannot serve.
 - `Permissions-Policy` denies camera, microphone, geolocation, USB, payment, magnetometer, accelerometer and the interest cohort signal. Gyroscope is allowed on the same origin so the card tilt on the draw screen works.
 - `Referrer-Policy: same-origin`.
 - `X-Content-Type-Options: nosniff`.

--- a/server/src/plugins/helmet.js
+++ b/server/src/plugins/helmet.js
@@ -21,6 +21,10 @@ export default fp(async function helmetPlugin(app) {
         'form-action': ["'self'"],
         'frame-ancestors': ["'none'"],
         'object-src': ["'none'"],
+        // Helmet ships `upgrade-insecure-requests` by default. On a plain-HTTP
+        // LAN deployment this rewrites every asset URL to https:// and breaks
+        // the page. Keep it only when we know we are served over HTTPS.
+        'upgrade-insecure-requests': config.cookieSecure ? [] : null,
       },
     },
     crossOriginEmbedderPolicy: false,


### PR DESCRIPTION
## Summary

- Helmet's default CSP appends `upgrade-insecure-requests` unconditionally. On a plain-HTTP LAN deployment (direct host-IP access, local `docker-compose.yml` without TLS) the browser rewrites every asset URL to `https://`, which the server cannot serve, so the page loads without styling or JS (`ERR_SSL_PROTOCOL_ERROR` on every asset).
- Gate the directive on `config.cookieSecure` so HTTPS deployments keep the hardening while plain-HTTP setups serve their own assets correctly. Same invariant already used for HSTS in this file.
- `docs/security.md` now states the directive is conditional; `CHANGELOG.md` gets a `Fixed` entry under `[Unreleased]`.

## Expected behaviours

- Behind any HTTPS variant in `deploy/` (or with `COOKIE_SECURE=1`): CSP still contains `upgrade-insecure-requests`. No regression.
- Plain-HTTP deployment (default `docker-compose.yml`, dev mode, host-IP access): CSP no longer contains `upgrade-insecure-requests`. Assets load over HTTP as requested by the page.
- All other CSP directives unchanged.