### PR TITLE
fix(seed): back-fill cards.emoji on upgrade + cut 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Existing instances upgrading to 1.6.0 stayed on the pile fallback icon for every card because the seed only runs against an empty deck. The boot sequence now back-fills `cards.emoji` from the seed JSON files for any row still at NULL, so per-card emojis appear without manual admin action. Emoji values that were already set (admin edits, custom imports) are left untouched.
+
 ## [1.6.0] - 2026-05-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-05-06
+
 ### Fixed
 
 - Existing instances upgrading to 1.6.0 stayed on the pile fallback icon for every card because the seed only runs against an empty deck. The boot sequence now back-fills `cards.emoji` from the seed JSON files for any row still at NULL, so per-card emojis appear without manual admin action. Emoji values that were already set (admin edits, custom imports) are left untouched.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/csrf-protection": "^7.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "type": "module",
   "description": "Couplecards backend — Fastify + node:sqlite",

--- a/server/src/db/seed.js
+++ b/server/src/db/seed.js
@@ -94,6 +94,37 @@ export async function runSeed(logger) {
     });
     applySeed();
     logger?.info({ count: deck.length, locales: Object.keys(deck[0]?.translations || {}) }, 'seeded card deck');
+  } else {
+    backfillCardEmoji(logger);
+  }
+}
+
+// Back-fills `cards.emoji` for rows still at NULL, using whatever the seed
+// JSON files declare for that id. Runs on every boot once the deck is already
+// seeded, so an instance that pre-dates the emoji column picks up the per-card
+// icons without manual admin action. Never overwrites a non-NULL value, so
+// emoji edits made through the admin UI are preserved.
+function backfillCardEmoji(logger) {
+  const db = getDb();
+  const stillNull = db.prepare('SELECT COUNT(*) AS n FROM cards WHERE emoji IS NULL').get().n;
+  if (stillNull === 0) return;
+  const deck = loadSeedDeck(logger);
+  if (deck.length === 0) return;
+  const update = db.prepare(`
+    UPDATE cards SET emoji = ?, updated_at = datetime('now')
+    WHERE id = ? AND emoji IS NULL
+  `);
+  let patched = 0;
+  const apply = transaction(() => {
+    for (const card of deck) {
+      if (!card.emoji) continue;
+      const info = update.run(card.emoji, card.id);
+      patched += info.changes;
+    }
+  });
+  apply();
+  if (patched > 0) {
+    logger?.info({ patched }, 'back-filled cards.emoji from seed files');
   }
 }
 


### PR DESCRIPTION
## Summary

- 1.6.0 ships per-card emojis in the seed JSON files but the seed only inserts cards when the deck is empty. Existing instances upgrading from 1.5.0 (or earlier) keep `cards.emoji = NULL` after migration 003 adds the column, so `/api/cards` returns `emoji: null` and the client falls back to the pile icon for every card.
- Add a boot-time back-fill that reads the seed JSON and fills `cards.emoji` for rows still at NULL. Idempotent. Admin-edited and custom-imported values are preserved (only NULLs are touched).
- `updated_at` is bumped on patched rows so the `/api/cards` ETag changes and clients refetch.
- Split into two commits per the one-concern rule: the fix, then the 1.6.1 cut.

## Expected behaviours

- Fresh install: behaviour unchanged (back-fill exits early when no row has NULL emoji).
- Upgrade from 1.6.0 with manual admin "sync from files" already done: back-fill exits early.
- Upgrade from 1.6.0 without manual sync: every NULL row gets its emoji on the first boot after the upgrade. The admin sees a single info log line `back-filled cards.emoji from seed files`. Clients refetch on the next `GET /api/cards` because the ETag has moved.
- Admin emoji overrides survive across boots (manually verified locally with `home-001` set to `admin-custom`: untouched after restart).