### PR TITLE
chore(release): cut version 1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.6.2] - 2026-05-09
+
+### Security
+
+- Bumped the transitive `fast-uri` dependency from 3.1.0 to 3.1.2 to pull in the upstream fixes for GHSA-q3j6-qgpj-74h6 and GHSA-v39h-62p7-jpjc, two URI-parsing vulnerabilities reachable through Fastify's request handling.
+
 ## [1.6.1] - 2026-05-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "@fastify/csrf-protection": "^7.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "type": "module",
   "description": "Couplecards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

- Patch release shipping the security bump from #46 (fast-uri 3.1.0 → 3.1.2, fixes GHSA-q3j6-qgpj-74h6 and GHSA-v39h-62p7-jpjc).
- Version bumped in `package.json`, `server/package.json`, and both lockfiles.
- CHANGELOG: new `[1.6.2] - 2026-05-09` Security section, fresh empty `[Unreleased]` above.

## Expected behaviours

- `npm view` / Docker image tagged `1.6.2` once the Release is published.
- No runtime change beyond the patched URI parser.