### PR TITLE
fix(auth): reject protocol-relative URLs in post-login next redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Security
+
+- Hardened the post-login `next` redirect to reject protocol-relative URLs (`//evil.example`). A crafted link like `/login.html?next=//attacker.example` previously sent the user off-origin after a successful login, opening a phishing path. The check now requires a single-slash same-origin path.
+
 ## [1.6.2] - 2026-05-09
 
 ### Security

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -39,7 +39,7 @@ function showError(scope, code, extra = {}) {
 function redirectAfterAuth(user) {
   const params = new URLSearchParams(location.search);
   const next = params.get('next');
-  if (next && next.startsWith('/')) {
+  if (next && /^\/[^/\\]/.test(next)) {
     location.replace(next);
     return;
   }


### PR DESCRIPTION
## Summary

- `redirectAfterAuth` accepted any `next` that started with `/`, but a value like `//evil.example` is a protocol-relative URL and sent the user off-origin after a successful login.
- Tighten the check to require a single-slash same-origin path (`/^\/[^/\]/`). Same-origin paths still pass.
- Verified `redirectToLogin` in `core/api.js` is safe: it builds `next` from `location.pathname`, never from external input.

## Expected behaviours

- `/login.html?next=/collection` still redirects to `/collection` after sign-in.
- `/login.html?next=//attacker.example` (or `?next=/\attacker.example`) ignores the parameter and falls back to the default destination (`/admin.html` for admins, `/` otherwise).
- No change to the non-redirect flows (forced password change, redirect on admin role).