### PR TITLE
chore(a11y): full accessibility pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Hardened the post-login `next` redirect to reject protocol-relative URLs (`//evil.example`). A crafted link like `/login.html?next=//attacker.example` previously sent the user off-origin after a successful login, opening a phishing path. The check now requires a single-slash same-origin path.
 
+### Added
+
+- Skip link on the admin page, jumping to the default users panel so keyboard users no longer have to Tab past the tablist on every visit.
+- Picking a new language now announces the new locale through the shared live region, so screen-reader users get spoken feedback after the selection. Uses Intl.DisplayNames so no new translation key was needed.
+
+### Fixed
+
+- Accessibility pass: every screen now starts at an h1 (the draw screen lifts the card title up and demotes the brand mark to a decorative div), the `<main>` landmark stays in the assistive-tech tree on older Firefox and Safari (previously stripped by `display: contents`), the language selects in Settings and admin expose a programmatic label, Collection filter chips ship as a real toggle-button group with `aria-pressed` instead of a half-implemented tablist, `role="alert"` error regions drop the contradictory `aria-live="polite"` override, the update banner now reads "A new version is available" instead of saying "Reload" twice, the home-screen pile buttons carry an explicit `type="button"`, and the card tilt animation honours `prefers-reduced-motion`.
+- Initial-password admin modal now traps focus, closes on Escape, and restores focus on close, matching the rest of the project's dialogs. The `withModal` helper moved from `deck-sync.js` to `ui/shell.js` so both call sites share the same focus-trap implementation.
+
 ## [1.6.2] - 2026-05-09
 
 ### Security

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -14,7 +14,7 @@ Audience: maintainers and contributors. This page summarises what the app implem
 
 ### Global
 
-The `<html lang>` attribute is updated whenever the i18n locale changes. Every interactive control is focusable and exposes a visible ring through `:focus-visible`. The first tab stop on the SPA shell is a "Skip to main content" link that moves focus to `<main id="main-content" tabindex="-1">`, and focus is moved to that same element after every route change so the new view is announced to screen readers. Toasts and card announcements live in `role="status"` regions. `prefers-reduced-motion` disables decorative animations, and `prefers-reduced-transparency` removes backdrop blurs.
+The `<html lang>` attribute is updated whenever the i18n locale changes, and the new locale's native name is pushed to a shared `#screen-announce` live region so screen-reader users hear feedback after picking a language. Every interactive control is focusable and exposes a visible ring through `:focus-visible`. The first tab stop on both the SPA shell and the admin page is a "Skip to main content" link: on the SPA it moves focus to `<main id="main-content" tabindex="-1">` (and focus is moved to that same element after every route change so the new view is announced to screen readers), on admin it jumps past the tablist to the default users panel. Toasts and card announcements live in `role="status"` regions. `prefers-reduced-motion` disables decorative animations including the parallax card tilt, and `prefers-reduced-transparency` removes backdrop blurs.
 
 ### Forms
 

--- a/public/admin.html
+++ b/public/admin.html
@@ -14,6 +14,7 @@
   <link rel="icon" href="/icons/icon.svg" type="image/svg+xml">
 </head>
 <body>
+  <a href="#admin-panel-users" class="skip-link" data-i18n="common.skipToContent">Skip to main content</a>
   <div id="screen-announce" class="sr-only" role="status" aria-live="polite"></div>
   <div id="admin-boot" class="boot-skeleton">
     <div class="boot-logo"><img class="title-icon" src="/icons/icon.svg" alt="" aria-hidden="true" draggable="false"><span>Couplecards</span></div>
@@ -31,7 +32,7 @@
       <button type="button" id="admin-tab-settings" class="admin-tab admin-tab-right" role="tab" aria-selected="false" tabindex="-1" data-i18n="settings.title">Settings</button>
     </nav>
 
-    <section id="admin-panel-users" class="admin-panel" role="tabpanel" aria-labelledby="admin-tab-users">
+    <section id="admin-panel-users" class="admin-panel" role="tabpanel" aria-labelledby="admin-tab-users" tabindex="-1">
       <form id="admin-create-user-form" class="admin-inline-form">
         <label for="admin-create-user-input" class="admin-inline-form-label" data-i18n="login.username">Username</label>
         <div class="admin-inline-form-row">

--- a/public/admin.html
+++ b/public/admin.html
@@ -14,6 +14,7 @@
   <link rel="icon" href="/icons/icon.svg" type="image/svg+xml">
 </head>
 <body>
+  <div id="screen-announce" class="sr-only" role="status" aria-live="polite"></div>
   <div id="admin-boot" class="boot-skeleton">
     <div class="boot-logo"><img class="title-icon" src="/icons/icon.svg" alt="" aria-hidden="true" draggable="false"><span>Couplecards</span></div>
     <div class="boot-pulse"></div>

--- a/public/admin.html
+++ b/public/admin.html
@@ -79,8 +79,8 @@
     <section id="admin-panel-settings" class="admin-panel" role="tabpanel" aria-labelledby="admin-tab-settings" hidden>
       <div class="settings">
         <div class="setting-row">
-          <span data-i18n="settings.language">Language</span>
-          <select id="admin-language" class="setting-select"></select>
+          <span id="admin-language-label" data-i18n="settings.language">Language</span>
+          <select id="admin-language" class="setting-select" aria-labelledby="admin-language-label"></select>
         </div>
         <div class="setting-row">
           <span data-i18n="settings.logout">Log out</span>

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -984,7 +984,7 @@
   cursor: pointer;
   transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
 }
-.collection-filters .chip[aria-selected='true'] {
+.collection-filters .chip[aria-pressed='true'] {
   background: linear-gradient(135deg, rgba(236, 90, 158, 0.22), rgba(140, 90, 220, 0.22));
   color: var(--text);
   border-color: rgba(236, 90, 158, 0.55);

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -260,7 +260,11 @@ body::before {
   top: calc(env(safe-area-inset-top, 0px) + 8px);
 }
 
-#main-content { display: contents; }
+#main-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
 
 /* Header (secondary screens) */
 .app-header {

--- a/public/index.html
+++ b/public/index.html
@@ -96,7 +96,7 @@
     </div>
 
     <div id="update-banner" class="update-banner" role="status" hidden>
-      <span data-i18n="common.reload">Reload</span>
+      <span data-i18n="common.updateAvailable">A new version is available.</span>
       <button type="button" class="btn btn-primary" id="update-reload" data-i18n="common.reload">Reload</button>
     </div>
   </div>

--- a/public/js/core/i18n.js
+++ b/public/js/core/i18n.js
@@ -116,10 +116,28 @@ export function applyI18n(root = document) {
   });
 }
 
-// Re-apply static translations whenever the locale changes.
-// Import site does not need to listen explicitly.
+// Announce the new locale via the shared #screen-announce live region so a
+// screen-reader user gets feedback after picking a language. Native display
+// name is enough; no extra i18n key needed.
+function announceLocale(locale) {
+  const el = document.getElementById('screen-announce');
+  if (!el) return;
+  let name = locale;
+  try { name = new Intl.DisplayNames([locale], { type: 'language' }).of(locale) || locale; } catch {}
+  el.textContent = name;
+  setTimeout(() => { el.textContent = ''; }, 1500);
+}
+
+// Re-apply static translations whenever the locale changes, and announce the
+// new locale (after the initial boot) so screen-reader users get feedback when
+// they pick a language.
+let announceArmed = false;
 if (typeof window !== 'undefined') {
   import('./events.js').then(({ on }) => {
-    on('i18n:change', () => applyI18n(document));
+    on('i18n:change', (locale) => {
+      applyI18n(document);
+      if (announceArmed) announceLocale(locale);
+      announceArmed = true;
+    });
   });
 }

--- a/public/js/features/admin/deck-sync.js
+++ b/public/js/features/admin/deck-sync.js
@@ -4,7 +4,7 @@
 
 import { request, ApiError } from '../../core/api.js';
 import { t, supportedLocales } from '../../core/i18n.js';
-import { toast } from '../../ui/shell.js';
+import { toast, withModal } from '../../ui/shell.js';
 import { escapeHtml } from '../../core/dom.js';
 
 const MAX_IMPORT_BYTES = 2 * 1024 * 1024;
@@ -89,80 +89,6 @@ function renderModeOptions(selectedMode) {
       </label>
     </fieldset>
   `;
-}
-
-function withModal({ title, bodyHtml, confirmLabel, cancelLabel, danger, onConfirm, onBodyReady }) {
-  const host = document.getElementById('modal');
-  const titleEl = document.getElementById('modal-title');
-  const bodyEl = document.getElementById('modal-body');
-  const confirmBtn = document.getElementById('modal-confirm');
-  const cancelBtn = document.getElementById('modal-cancel');
-  const backdrop = host?.querySelector('[data-modal-close]');
-  if (!host) return { close: () => {} };
-
-  const previouslyFocused = document.activeElement;
-
-  titleEl.textContent = title;
-  bodyEl.innerHTML = bodyHtml;
-  confirmBtn.textContent = confirmLabel;
-  confirmBtn.classList.toggle('btn-danger', !!danger);
-  confirmBtn.classList.toggle('btn-primary', !danger);
-  confirmBtn.disabled = false;
-  cancelBtn.hidden = false;
-  cancelBtn.textContent = cancelLabel;
-  host.hidden = false;
-
-  // Every focusable control currently inside the modal (body inputs +
-  // confirm/cancel). Queried on each Tab so dynamic bodies (preview summary,
-  // mode switches) stay in the trap.
-  const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-  const getFocusables = () => Array.from(host.querySelectorAll(FOCUSABLE))
-    .filter((el) => !el.hidden && el.offsetParent !== null);
-
-  const close = () => {
-    host.hidden = true;
-    confirmBtn.removeEventListener('click', handler);
-    cancelBtn.removeEventListener('click', cancel);
-    backdrop?.removeEventListener('click', cancel);
-    document.removeEventListener('keydown', onKey);
-    if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
-      try { previouslyFocused.focus(); } catch {}
-    }
-  };
-  const cancel = () => close();
-  const handler = async () => {
-    try { await onConfirm({ close, confirmBtn }); }
-    catch {}
-  };
-  const onKey = (event) => {
-    if (event.key === 'Escape') { event.preventDefault(); cancel(); return; }
-    if (event.key !== 'Tab') return;
-    const items = getFocusables();
-    if (items.length === 0) return;
-    const first = items[0];
-    const last = items[items.length - 1];
-    if (event.shiftKey && document.activeElement === first) {
-      event.preventDefault();
-      last.focus();
-    } else if (!event.shiftKey && document.activeElement === last) {
-      event.preventDefault();
-      first.focus();
-    }
-  };
-
-  confirmBtn.addEventListener('click', handler);
-  cancelBtn.addEventListener('click', cancel);
-  backdrop?.addEventListener('click', cancel);
-  document.addEventListener('keydown', onKey);
-  onBodyReady?.({ close });
-
-  // Defer initial focus so the body has rendered its first focusable control.
-  setTimeout(() => {
-    const [first] = getFocusables();
-    (first || confirmBtn).focus();
-  }, 50);
-
-  return { close };
 }
 
 function openSyncDialog() {

--- a/public/js/features/admin/users.js
+++ b/public/js/features/admin/users.js
@@ -4,7 +4,7 @@
 import { request } from '../../core/api.js';
 import { t, fmtDateLong } from '../../core/i18n.js';
 import { on } from '../../core/events.js';
-import { toast, showConfirm } from '../../ui/shell.js';
+import { toast, showConfirm, withModal } from '../../ui/shell.js';
 import { escapeHtml } from '../../core/dom.js';
 
 let allUsers = [];
@@ -59,35 +59,27 @@ function renderUsersList(users) {
 }
 
 function showInitialPassword(username, password) {
-  const host = document.getElementById('modal');
-  const titleEl = document.getElementById('modal-title');
-  const bodyEl = document.getElementById('modal-body');
-  const confirmBtn = document.getElementById('modal-confirm');
-  const cancelBtn = document.getElementById('modal-cancel');
-  if (!host || !titleEl || !bodyEl || !confirmBtn || !cancelBtn) return;
-
-  titleEl.textContent = t('admin.users.initialPassword.title', { username });
-  bodyEl.innerHTML = `
-    <p>${escapeHtml(t('admin.users.initialPassword.warn'))}</p>
-    <div class="initial-password-box">
-      <code id="initial-password-value">${escapeHtml(password)}</code>
-      <button type="button" class="btn" id="initial-password-copy">${escapeHtml(t('admin.users.initialPassword.copy'))}</button>
-    </div>
-  `;
-  confirmBtn.textContent = t('admin.users.initialPassword.close');
-  cancelBtn.hidden = true;
-  confirmBtn.classList.add('btn-primary');
-  confirmBtn.classList.remove('btn-danger');
-  host.hidden = false;
-
-  document.getElementById('initial-password-copy').addEventListener('click', async () => {
-    try {
-      await navigator.clipboard.writeText(password);
-      toast(t('common.copied'));
-    } catch { /* clipboard may be blocked */ }
+  withModal({
+    title: t('admin.users.initialPassword.title', { username }),
+    bodyHtml: `
+      <p>${escapeHtml(t('admin.users.initialPassword.warn'))}</p>
+      <div class="initial-password-box">
+        <code id="initial-password-value">${escapeHtml(password)}</code>
+        <button type="button" class="btn" id="initial-password-copy">${escapeHtml(t('admin.users.initialPassword.copy'))}</button>
+      </div>
+    `,
+    confirmLabel: t('admin.users.initialPassword.close'),
+    cancelLabel: null,
+    onBodyReady: () => {
+      document.getElementById('initial-password-copy')?.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(password);
+          toast(t('common.copied'));
+        } catch { /* clipboard may be blocked */ }
+      });
+    },
+    onConfirm: ({ close }) => close(),
   });
-  const onClose = () => { host.hidden = true; confirmBtn.removeEventListener('click', onClose); };
-  confirmBtn.addEventListener('click', onClose);
 }
 
 export async function renderUsers() {

--- a/public/js/features/collection/collection.js
+++ b/public/js/features/collection/collection.js
@@ -192,7 +192,7 @@ function onFilterClick(event) {
   if (!btn) return;
   currentFilter = btn.dataset.filter;
   document.querySelectorAll('[data-filter]').forEach((b) => {
-    b.setAttribute('aria-selected', b === btn ? 'true' : 'false');
+    b.setAttribute('aria-pressed', b === btn ? 'true' : 'false');
   });
   render();
 }
@@ -201,7 +201,7 @@ export function mount() {
   document.getElementById('btn-back-home')?.addEventListener('click', () => navigate('home'));
   document.querySelector('.collection-filters')?.addEventListener('click', onFilterClick);
   document.querySelectorAll('[data-filter]').forEach((b) => {
-    b.setAttribute('aria-selected', b.dataset.filter === currentFilter ? 'true' : 'false');
+    b.setAttribute('aria-pressed', b.dataset.filter === currentFilter ? 'true' : 'false');
   });
 
   // The most recently drawn card pulses so the user can spot it immediately

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -190,6 +190,7 @@ let isReturning = false;
 let returnRaf = 0;
 
 function applyTilt(rx, ry) {
+  if (prefersReducedMotion()) return;
   const tilt = $('card-tilt');
   const front = document.querySelector('#card-flip .card-front');
   if (!tilt || !front) return;
@@ -405,6 +406,7 @@ function attachTilt() {
 
 function attachOrientation() {
   if (orientationAttached) return;
+  if (prefersReducedMotion()) return;
   orientationAttached = true;
   let baseBeta = null, baseGamma = null;
   const CLAMP = CONFIG.tilt.orientationClampDeg;

--- a/public/js/features/settings/settings.js
+++ b/public/js/features/settings/settings.js
@@ -138,7 +138,7 @@ async function openChangePasswordDialog() {
         <span>${t('changePassword.confirm')}</span>
         <input type="password" id="cp-confirm" autocomplete="new-password" required minlength="12">
       </label>
-      <div class="cp-error" id="cp-error" role="alert" aria-live="polite"></div>
+      <div class="cp-error" id="cp-error" role="alert"></div>
     </form>
   `;
   confirmBtn.textContent = t('changePassword.submit');

--- a/public/js/ui/shell.js
+++ b/public/js/ui/shell.js
@@ -131,6 +131,81 @@ export function showConfirm({
   });
 }
 
+// Lower-level modal helper for richer dialogs (custom body, async confirm,
+// optional cancel button). Like showConfirm but caller-driven: returns
+// { close } and the body can hold any markup. Pass cancelLabel: null to
+// hide the cancel button for one-button dialogs.
+export function withModal({ title, bodyHtml, confirmLabel, cancelLabel, danger, onConfirm, onBodyReady }) {
+  const host = document.getElementById('modal');
+  const titleEl = document.getElementById('modal-title');
+  const bodyEl = document.getElementById('modal-body');
+  const confirmBtn = document.getElementById('modal-confirm');
+  const cancelBtn = document.getElementById('modal-cancel');
+  const backdrop = host?.querySelector('[data-modal-close]');
+  if (!host) return { close: () => {} };
+
+  const previouslyFocused = document.activeElement;
+
+  titleEl.textContent = title;
+  bodyEl.innerHTML = bodyHtml;
+  confirmBtn.textContent = confirmLabel;
+  confirmBtn.classList.toggle('btn-danger', !!danger);
+  confirmBtn.classList.toggle('btn-primary', !danger);
+  confirmBtn.disabled = false;
+  const showCancel = cancelLabel != null;
+  cancelBtn.hidden = !showCancel;
+  if (showCancel) cancelBtn.textContent = cancelLabel;
+  host.hidden = false;
+
+  const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  const getFocusables = () => Array.from(host.querySelectorAll(FOCUSABLE))
+    .filter((el) => !el.hidden && el.offsetParent !== null);
+
+  const close = () => {
+    host.hidden = true;
+    confirmBtn.removeEventListener('click', handler);
+    cancelBtn.removeEventListener('click', cancel);
+    backdrop?.removeEventListener('click', cancel);
+    document.removeEventListener('keydown', onKey);
+    if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+      try { previouslyFocused.focus(); } catch {}
+    }
+  };
+  const cancel = () => close();
+  const handler = async () => {
+    try { await onConfirm?.({ close, confirmBtn }); }
+    catch {}
+  };
+  const onKey = (event) => {
+    if (event.key === 'Escape') { event.preventDefault(); cancel(); return; }
+    if (event.key !== 'Tab') return;
+    const items = getFocusables();
+    if (items.length === 0) return;
+    const first = items[0];
+    const last = items[items.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  confirmBtn.addEventListener('click', handler);
+  cancelBtn.addEventListener('click', cancel);
+  backdrop?.addEventListener('click', cancel);
+  document.addEventListener('keydown', onKey);
+  onBodyReady?.({ close });
+
+  setTimeout(() => {
+    const [first] = getFocusables();
+    (first || confirmBtn).focus();
+  }, 50);
+
+  return { close };
+}
+
 // Screen-wake lock while a draw animation is in progress.
 let wakeLockSentinel = null;
 export async function requestWakeLock() {

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -9,6 +9,7 @@
   "common.edit": "Bearbeiten",
   "common.back": "Zurück",
   "common.reload": "Neu laden",
+  "common.updateAvailable": "Eine neue Version ist verfügbar.",
   "common.copied": "Kopiert",
   "common.dateAtTime": "{{date}} um {{time}}",
   "common.skipToContent": "Zum Hauptinhalt springen",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -9,6 +9,7 @@
   "common.edit": "Edit",
   "common.back": "Back",
   "common.reload": "Reload",
+  "common.updateAvailable": "A new version is available.",
   "common.copied": "Copied",
   "common.dateAtTime": "{{date}} at {{time}}",
   "common.skipToContent": "Skip to main content",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -9,6 +9,7 @@
   "common.edit": "Editar",
   "common.back": "Atrás",
   "common.reload": "Recargar",
+  "common.updateAvailable": "Hay una nueva versión disponible.",
   "common.copied": "Copiado",
   "common.dateAtTime": "{{date}} a las {{time}}",
   "common.skipToContent": "Saltar al contenido principal",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -9,6 +9,7 @@
   "common.edit": "Modifier",
   "common.back": "Retour",
   "common.reload": "Recharger",
+  "common.updateAvailable": "Une nouvelle version est disponible.",
   "common.copied": "Copié",
   "common.dateAtTime": "{{date}} à {{time}}",
   "common.skipToContent": "Aller au contenu principal",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -9,6 +9,7 @@
   "common.edit": "Modifica",
   "common.back": "Indietro",
   "common.reload": "Ricarica",
+  "common.updateAvailable": "È disponibile una nuova versione.",
   "common.copied": "Copiato",
   "common.dateAtTime": "{{date}} alle {{time}}",
   "common.skipToContent": "Vai al contenuto principale",

--- a/public/login.html
+++ b/public/login.html
@@ -39,7 +39,7 @@
                  aria-describedby="login-error"
                  required>
         </label>
-        <div class="auth-error" id="login-error" role="alert" aria-live="polite"></div>
+        <div class="auth-error" id="login-error" role="alert"></div>
         <button type="submit" class="btn btn-primary" data-i18n="login.submit">Sign in</button>
       </form>
     </section>
@@ -66,7 +66,7 @@
                  aria-describedby="change-error"
                  required minlength="12">
         </label>
-        <div class="auth-error" id="change-error" role="alert" aria-live="polite"></div>
+        <div class="auth-error" id="change-error" role="alert"></div>
         <button type="submit" class="btn btn-primary" data-i18n="changePassword.submit">Update my password</button>
       </form>
     </section>

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v29';
+const VERSION = 'couplecards-v30';
 const SHELL = [
   '/',
   '/index.html',

--- a/public/views/collection.html
+++ b/public/views/collection.html
@@ -3,7 +3,7 @@
   <button class="icon-btn" id="btn-back-home" data-i18n-attr="aria-label:common.back" type="button">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
   </button>
-  <h2 class="title" data-i18n="collection.title">Collection</h2>
+  <h1 class="title" data-i18n="collection.title">Collection</h1>
   <span></span>
 </header>
 <div class="collection-toolbar">

--- a/public/views/collection.html
+++ b/public/views/collection.html
@@ -8,11 +8,11 @@
 </header>
 <div class="collection-toolbar">
   <div class="collection-counter" id="collection-counter"></div>
-  <div class="collection-filters" role="tablist" data-i18n-attr="aria-label:collection.title">
-    <button type="button" class="chip" role="tab" data-filter="all" aria-selected="true" data-i18n="collection.filter.all">All</button>
-    <button type="button" class="chip" role="tab" data-filter="home" aria-selected="false" data-i18n="piles.home.label">Home</button>
-    <button type="button" class="chip" role="tab" data-filter="outdoor" aria-selected="false" data-i18n="piles.outdoor.label">Outdoor</button>
-    <button type="button" class="chip" role="tab" data-filter="rare" aria-selected="false" data-i18n="collection.filter.rare">Rare</button>
+  <div class="collection-filters" role="group" data-i18n-attr="aria-label:collection.title">
+    <button type="button" class="chip" data-filter="all" aria-pressed="true" data-i18n="collection.filter.all">All</button>
+    <button type="button" class="chip" data-filter="home" aria-pressed="false" data-i18n="piles.home.label">Home</button>
+    <button type="button" class="chip" data-filter="outdoor" aria-pressed="false" data-i18n="piles.outdoor.label">Outdoor</button>
+    <button type="button" class="chip" data-filter="rare" aria-pressed="false" data-i18n="collection.filter.rare">Rare</button>
   </div>
 </div>
 <div class="collection-grid" id="collection-grid"></div>

--- a/public/views/draw.html
+++ b/public/views/draw.html
@@ -1,9 +1,9 @@
 <!-- SPDX-License-Identifier: MIT -->
 <div id="screen-draw" class="screen screen-draw">
-  <h1 class="draw-title">
-    <img class="title-icon" src="/icons/icon.svg" alt="" aria-hidden="true" draggable="false">
+  <div class="draw-title" aria-hidden="true">
+    <img class="title-icon" src="/icons/icon.svg" alt="" draggable="false">
     <span data-i18n="draw.title">Couplecards</span>
-  </h1>
+  </div>
   <div class="draw-stage" id="draw-stage">
     <div class="bg-glow" id="bg-glow"></div>
     <div class="ripples" id="ripples"></div>
@@ -31,7 +31,7 @@
           <div class="card-frame">
             <div class="card-pile-label" id="card-pile-label"></div>
             <div class="card-art"><span class="card-art-emoji" id="card-emoji"></span></div>
-            <h2 class="card-title" id="card-title"></h2>
+            <h1 class="card-title" id="card-title"></h1>
             <div class="card-divider" aria-hidden="true">
               <span class="card-divider-ornament"><img class="heart-icon" src="/icons/heart-gold.svg" alt="" draggable="false"></span>
             </div>

--- a/public/views/history.html
+++ b/public/views/history.html
@@ -3,7 +3,7 @@
   <button class="icon-btn" id="btn-back-home" data-i18n-attr="aria-label:common.back" type="button">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
   </button>
-  <h2 class="title" data-i18n="history.title">History</h2>
+  <h1 class="title" data-i18n="history.title">History</h1>
   <span></span>
 </header>
 <div class="list" id="history-list"></div>

--- a/public/views/home.html
+++ b/public/views/home.html
@@ -7,7 +7,7 @@
 </header>
 
 <div class="piles">
-  <button class="pile pile-home" data-pile="home" data-i18n-attr="aria-label:home.pile.home.aria">
+  <button type="button" class="pile pile-home" data-pile="home" data-i18n-attr="aria-label:home.pile.home.aria">
     <span class="stack-card stack-card-back stack-card-3" aria-hidden="true"></span>
     <span class="stack-card stack-card-back stack-card-2" aria-hidden="true"></span>
     <span class="stack-card stack-card-top">
@@ -17,7 +17,7 @@
       <span class="pile-low-hint" id="low-home" data-i18n="home.pile.lowHint" hidden>Almost empty</span>
     </span>
   </button>
-  <button class="pile pile-outdoor" data-pile="outdoor" data-i18n-attr="aria-label:home.pile.outdoor.aria">
+  <button type="button" class="pile pile-outdoor" data-pile="outdoor" data-i18n-attr="aria-label:home.pile.outdoor.aria">
     <span class="stack-card stack-card-back stack-card-3" aria-hidden="true"></span>
     <span class="stack-card stack-card-back stack-card-2" aria-hidden="true"></span>
     <span class="stack-card stack-card-top">

--- a/public/views/rules.html
+++ b/public/views/rules.html
@@ -3,7 +3,7 @@
   <button class="icon-btn" id="btn-back-home" data-i18n-attr="aria-label:common.back" type="button">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
   </button>
-  <h2 class="title" data-i18n="rules.title">Rules</h2>
+  <h1 class="title" data-i18n="rules.title">Rules</h1>
   <span></span>
 </header>
 

--- a/public/views/settings.html
+++ b/public/views/settings.html
@@ -12,8 +12,8 @@
     <button class="btn btn-sm btn-primary" id="install-btn" type="button" data-i18n="settings.install.action">Install</button>
   </div>
   <div class="setting-row">
-    <span data-i18n="settings.language">Language</span>
-    <select id="setting-language" class="setting-select"></select>
+    <span id="setting-language-label" data-i18n="settings.language">Language</span>
+    <select id="setting-language" class="setting-select" aria-labelledby="setting-language-label"></select>
   </div>
   <div class="setting-row">
     <span id="setting-sounds-label" data-i18n="settings.sounds">Sound effects</span>

--- a/public/views/settings.html
+++ b/public/views/settings.html
@@ -3,7 +3,7 @@
   <button class="icon-btn" id="btn-back-home" data-i18n-attr="aria-label:common.back" type="button">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
   </button>
-  <h2 class="title" data-i18n="settings.title">Settings</h2>
+  <h1 class="title" data-i18n="settings.title">Settings</h1>
   <span></span>
 </header>
 <div class="settings">


### PR DESCRIPTION
## Summary

Twelve atomic commits covering one HIGH, eight MEDIUM and one LOW accessibility finding plus the SW + docs wrap-up. Each commit is independently revertable.

### HIGH
- Initial-password admin modal now traps focus, closes on Escape, restores focus on close. The `withModal` helper moved from `deck-sync.js` to `ui/shell.js` (new `cancelLabel: null` option for one-button dialogs) so both call sites share the same trap.
- Language selects in Settings and admin expose a programmatic label (`aria-labelledby`).

### MEDIUM
- Every screen now starts at an h1. Draw screen lifts the card title up; brand mark is decorative.
- `<main>` landmark stays in the AT tree on older Firefox and Safari (`display: contents` replaced with a proper flex container).
- Collection filter chips become a toggle-button group (`aria-pressed`) instead of a half-implemented tablist.
- `role="alert"` regions drop the contradictory `aria-live="polite"` override.
- Locale changes announced via the shared `#screen-announce` live region (also added to admin shell). Uses `Intl.DisplayNames`, no new translation keys.
- Update banner now reads "A new version is available." (new `common.updateAvailable` key in en/fr/de/it/es).
- Home pile buttons get explicit `type="button"`.
- Skip link on the admin page jumps past the tablist to the default users panel.

### LOW
- Card tilt animation honours `prefers-reduced-motion` (`applyTilt` and `attachOrientation` short-circuit when set; swipe gestures untouched).

### Wrap-up
- SW cache key bumped v29 → v30.
- `CHANGELOG.md` `[Unreleased]` updated.
- `docs/accessibility.md` mentions the new admin skip link, locale-change announcement, and reduced-motion tilt behaviour.

## Expected behaviours

- Creating a user or resetting a password: the password-reveal modal traps Tab, Escape closes it, focus returns to the row that triggered the action.
- Language selects on Settings and admin announce as "Language combobox" plus the selected option to screen readers.
- VoiceOver / NVDA / JAWS heading-navigation reaches an `<h1>` first on every screen, including `/#/draw` where the card title now carries that role.
- Bottom and admin tablist navigation unchanged.
- Drawing a card under `prefers-reduced-motion`: card stays flat, particles / hearts / burst / ripples still suppressed.

## Test plan

- [ ] Tab through Settings, admin Users (after creating a user), admin Cards (open the editor, deck sync, import).
- [ ] Smoke-test the draw flow with `prefers-reduced-motion` toggled on in DevTools rendering panel.
- [ ] Smoke-test the SPA route changes with a screen reader (focus should land on `<main>` and announce the new heading).
- [ ] Switch language in Settings: a brief "Français" / "English" / etc. is announced.
- [ ] Update banner: trigger a SW update (bump v30 → v31 locally) and read the banner.