### PR TITLE
chore(ui): full visual / UI polish pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Visual polish pass: the foil card halo is no longer clipped by the card-face overflow and now actually pulses around the rim; the "Rare" suffix on the foil pile label is localised in en/fr/de/it/es instead of hardcoded English in CSS; the update banner sits above the bottom navigation instead of covering its rightmost links; the Collection counter, filters and tile grid align with the screen title rather than starting 14px further in; the card flip lands on the same frame inset as the back so the dashed liner stays put; modal padding is uniform so the footer buttons no longer crowd the right wall; the boot skeleton no longer flashes a flat fill against the body gradient, and its logo and bar animations now share a 1.2s cadence; the locked-foil tile halo wraps the tile flush instead of leaking a pixel of conic gradient; the .heart-icon glow stops bleeding onto the small in-card ornament; the .btn:hover brightness filter is dropped so the per-variant shadow boost reads cleanly.
+- The .action-tag.banned pill background is now tied to var(--danger) via color-mix instead of a stale literal rgba from a previous palette, so the badge fill matches its text.
+
+### Changed
+
+- Internal CSS cleanup: removed the dead `.home-nav` / `.btn-nav` block that no template emits, removed `pile-badge.home`, `pile-badge.outdoor` and `field-inline` duplicates from `admin.css` (already in `style.css`), and routed the remaining `'Fraunces'` / `'Inter'` literals through `var(--font-display)` / `var(--font)`.
+
 ### Security
 
 - Hardened the post-login `next` redirect to reject protocol-relative URLs (`//evil.example`). A crafted link like `/login.html?next=//attacker.example` previously sent the user off-origin after a successful login, opening a phishing path. The check now requires a single-slash same-origin path.

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -161,20 +161,6 @@ body { padding: 20px 16px calc(env(safe-area-inset-bottom, 0px) + 24px); }
   font-size: 0.82rem;
 }
 
-.pile-badge.home {
-  background: linear-gradient(135deg, var(--home-1), var(--home-2));
-}
-.pile-badge.outdoor {
-  background: linear-gradient(135deg, var(--outdoor-1), var(--outdoor-2));
-}
-
-.field-inline {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 2px;
-}
-
 .deck-tools {
   background-image: var(--tile-surface);
   background-color: var(--surface);

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -406,12 +406,15 @@
   58%      { opacity: 1; transform: scale(1)   rotate(180deg); }
 }
 
-/* Golden halo pulsing around the foil card */
-.card-front.is-foil::after {
+/* Golden halo pulsing around the foil card. Placed on .card-flip (which has
+   no overflow:hidden) rather than on .card-front, whose .card-face wrapper
+   clips it to invisibility. Uses ::before so the pile-specific ::after glow
+   on .card-flip can co-exist. */
+.card-flip:has(.card-front.is-foil)::before {
   content: "";
   position: absolute;
   inset: -16px;
-  border-radius: inherit;
+  border-radius: 24px;
   box-shadow: 0 0 40px 4px rgba(255, 210, 140, 0.25);
   pointer-events: none;
   z-index: -1;
@@ -429,7 +432,7 @@
   .card-front.is-foil .card-frame::before,
   .card-front.is-foil .card-art::before,
   .foil-sparkle,
-  .card-front.is-foil::after { animation: none; }
+  .card-flip:has(.card-front.is-foil)::before { animation: none; }
   .foil-sparkle { opacity: 0.6; }
 }
 .card-frame {

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -873,7 +873,6 @@
   border-color: rgba(255, 255, 255, 0.18);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
-  font-size: 0.92rem;
 }
 .draw-actions .btn {
   padding: 12px 14px;

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -200,7 +200,7 @@
 }
 .card-back-frame {
   position: absolute;
-  inset: 26px;
+  inset: 14px;
   border: 2px dashed rgba(255, 210, 140, 0.38);
   border-radius: 14px;
   display: flex;

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -964,7 +964,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 10px;
-  padding: 0 14px 12px;
+  padding: 0 0 12px;
 }
 .collection-filters {
   display: inline-flex;
@@ -1036,7 +1036,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(108px, 1fr));
   gap: 10px;
-  padding: 0 14px 24px;
+  padding: 0 0 24px;
 }
 @media (min-width: 720px) {
   .collection-grid { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 14px; }

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -1000,7 +1000,7 @@
   line-height: 1;
 }
 .counter-num {
-  font-family: 'Fraunces', Georgia, serif;
+  font-family: var(--font-display);
   font-size: 1.45rem;
   font-weight: 700;
   letter-spacing: -0.01em;
@@ -1017,7 +1017,7 @@
   margin: 0 1px;
 }
 .counter-total {
-  font-family: 'Fraunces', Georgia, serif;
+  font-family: var(--font-display);
   font-size: 1.05rem;
   font-weight: 600;
   color: var(--text);
@@ -1142,7 +1142,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: 'Inter', system-ui, sans-serif;
+  font-family: var(--font);
   font-size: 2.8rem;
   font-weight: 700;
   color: rgba(255, 255, 255, 0.22);

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -335,12 +335,8 @@
 /* Golden "Rare" tag */
 .card-front.is-foil .card-pile-label {
   color: #ffd37a;
-  text-shadow: 0 0 10px rgba(255, 210, 140, 0.5);
-}
-.card-front.is-foil .card-pile-label::after {
-  content: " · Rare";
-  color: #ffd37a;
   font-weight: 800;
+  text-shadow: 0 0 10px rgba(255, 210, 140, 0.5);
 }
 
 /* Illustration panel with a pronounced golden halo */
@@ -1213,8 +1209,6 @@
    card; hide them at this scale, the gold border alone signals rarity. */
 .coll-tile .card-front.is-foil::after { display: none; }
 .coll-tile .foil-sparkles { display: none; }
-/* The "· Rare" suffix on the pile label crowds the tiny label area. */
-.coll-tile .card-front.is-foil .card-pile-label::after { content: ''; }
 /* The heart-pattern overlay on the illustration panel uses 44px tiles at
    full size; in the mini card we scale it down so the density matches, and
    slow the slide so the perceptual speed lines up with the revealed card. */

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -1157,7 +1157,7 @@
   content: '';
   position: absolute;
   inset: -2px;
-  border-radius: 13px;
+  border-radius: 14px;
   background: conic-gradient(
     from 135deg,
     #ff8aa3, #ffce8a, #fff0a3, #b3f5c5, #a3d8ff, #d3a3ff, #ff8aa3

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1019,11 +1019,13 @@ body::before {
   align-items: center;
   justify-content: center;
   gap: 24px;
-  background: var(--bg-0);
   z-index: 3000;
+  /* Transparent so the body's radial+linear gradient shows through and
+     dismissing the skeleton does not flash a flat fill behind it. */
+  background: transparent;
 }
 .boot-logo {
-  animation: boot-logo-pulse 1.4s ease-in-out infinite;
+  animation: boot-logo-pulse 1.2s ease-in-out infinite;
 }
 @keyframes boot-logo-pulse {
   0%, 100% { opacity: 0.55; transform: scale(0.98); }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -702,7 +702,7 @@ body::before {
   color: #3ddb96;
 }
 .action-tag.banned {
-  background: rgba(217, 50, 68, 0.15);
+  background: color-mix(in srgb, var(--danger) 18%, transparent);
   color: var(--danger);
 }
 .action-tag.admin-role,

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -640,27 +640,6 @@ body::before {
   100% { transform: scale(1); background: rgba(0, 0, 0, 0.28); }
 }
 
-.home-nav {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
-}
-.btn-nav {
-  flex-direction: column;
-  gap: 4px;
-  padding: 10px 8px;
-  font-size: 0.78rem;
-  min-height: 64px;
-  border-radius: var(--radius-md);
-}
-.btn-nav svg {
-  width: 22px;
-  height: 22px;
-  color: var(--accent);
-  flex-shrink: 0;
-}
-.btn-nav span { line-height: 1.2; }
-
 /* Lists */
 .list {
   display: flex;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -17,7 +17,6 @@
   vertical-align: -0.12em;
   user-select: none;
   -webkit-user-drag: none;
-  filter: drop-shadow(0 0 10px rgba(255, 210, 140, 0.45));
 }
 
 /* Inline emoji in text */

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1067,7 +1067,7 @@ body::before {
 .update-banner {
   position: fixed;
   left: 50%;
-  bottom: calc(env(safe-area-inset-bottom, 0px) + 16px);
+  bottom: calc(94px + env(safe-area-inset-bottom, 0px));
   transform: translateX(-50%);
   display: flex;
   align-items: center;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -979,7 +979,7 @@ body::before {
   background-color: var(--surface-solid);
   border: 1px solid var(--surface-border);
   border-radius: var(--radius-lg);
-  padding: 24px 22px 18px;
+  padding: 22px;
   max-width: 460px;
   width: 100%;
   max-height: calc(100vh - 40px);

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -469,7 +469,6 @@ body::before {
 @media (hover: hover) {
   .pile:hover { transform: translateY(-5px); filter: brightness(1.05); }
   .pile:hover .stack-card-top { box-shadow: 0 16px 40px rgba(236, 90, 158, 0.25); }
-  .btn:hover:not(:disabled) { filter: brightness(1.05); }
 }
 .pile:active { transform: scale(0.97); }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -646,8 +646,8 @@ body::before {
   flex-direction: column;
   gap: 10px;
   padding: 12px 0;
-  mask-image: linear-gradient(to bottom, transparent 0, black 16px, black calc(100% - 16px), transparent 100%);
-  -webkit-mask-image: linear-gradient(to bottom, transparent 0, black 16px, black calc(100% - 16px), transparent 100%);
+  mask-image: linear-gradient(to bottom, transparent 0, black 16px, black calc(100% - 8px), transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, black 16px, black calc(100% - 8px), transparent 100%);
 }
 .list-item {
   background-image: var(--tile-surface);

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -489,7 +489,9 @@ export async function startDraw(pile) {
 
   applyCardText(card);
   $('card-emoji').innerHTML = emojiImgHTML(card.emoji || (pile === 'home' ? 'house' : 'city'));
-  $('card-pile-label').textContent = t(`piles.${pile}.label`);
+  $('card-pile-label').textContent = card.foil
+    ? `${t(`piles.${pile}.label`)} · ${t('draw.foil.rare')}`
+    : t(`piles.${pile}.label`);
   const frontEl = document.querySelector('#card-flip .card-front');
   frontEl.classList.remove('for-home', 'for-outdoor', 'is-foil');
   frontEl.classList.add(pile === 'home' ? 'for-home' : 'for-outdoor');
@@ -661,7 +663,9 @@ export function showCardDirectly(cardId) {
   const pile = card.pile;
   applyCardText(card);
   $('card-emoji').innerHTML = emojiImgHTML(card.emoji || (pile === 'home' ? 'house' : 'city'));
-  $('card-pile-label').textContent = t(`piles.${pile}.label`);
+  $('card-pile-label').textContent = card.foil
+    ? `${t(`piles.${pile}.label`)} · ${t('draw.foil.rare')}`
+    : t(`piles.${pile}.label`);
   const frontEl = document.querySelector('#card-flip .card-front');
   frontEl.classList.remove('for-home', 'for-outdoor', 'is-foil');
   frontEl.classList.add(pile === 'home' ? 'for-home' : 'for-outdoor');

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -60,6 +60,7 @@
   "draw.action.close": "Vorschau schließen",
   "draw.swipe.ban": "Verbannen",
   "draw.swipe.return": "Zurück\nauf den Stapel",
+  "draw.foil.rare": "Selten",
   "draw.toast.returned": "Karte auf den Stapel zurückgelegt",
   "draw.toast.banned": "Karte verbannt",
   "draw.toast.empty": "Keine Karten mehr in diesem Stapel",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -60,6 +60,7 @@
   "draw.action.close": "Close preview",
   "draw.swipe.ban": "Ban",
   "draw.swipe.return": "Return to the pile",
+  "draw.foil.rare": "Rare",
   "draw.toast.returned": "Card returned to the pile",
   "draw.toast.banned": "Card banned",
   "draw.toast.empty": "No more cards in this pile",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -60,6 +60,7 @@
   "draw.action.close": "Cerrar vista previa",
   "draw.swipe.ban": "Vetar",
   "draw.swipe.return": "Devolver\nal montón",
+  "draw.foil.rare": "Rara",
   "draw.toast.returned": "Carta devuelta al montón",
   "draw.toast.banned": "Carta vetada",
   "draw.toast.empty": "No quedan cartas en este montón",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -60,6 +60,7 @@
   "draw.action.close": "Fermer l'aperçu",
   "draw.swipe.ban": "Bannir",
   "draw.swipe.return": "Remettre\ndans la pioche",
+  "draw.foil.rare": "Rare",
   "draw.toast.returned": "Carte remise dans la pioche",
   "draw.toast.banned": "Carte bannie",
   "draw.toast.empty": "Plus de cartes dans ce tas",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -60,6 +60,7 @@
   "draw.action.close": "Chiudi anteprima",
   "draw.swipe.ban": "Escludi",
   "draw.swipe.return": "Rimetti\nnel mazzo",
+  "draw.foil.rare": "Rara",
   "draw.toast.returned": "Carta rimessa nel mazzo",
   "draw.toast.banned": "Carta esclusa",
   "draw.toast.empty": "Nessuna carta in questo mazzo",

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v31';
+const VERSION = 'couplecards-v32';
 const SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

Seventeen atomic commits covering all valid findings from the UI review (one false positive on .empty specificity was discarded), plus the SW + CHANGELOG wrap-up. Pure visual fixes, no UX / a11y / security overlap with the recent passes.

### HIGH

- Foil card halo is no longer clipped to invisibility by the `.card-face { overflow: hidden }` parent. Halo moved onto `.card-flip` via `:has()` (uses `::before` to avoid clashing with the existing pile glow `::after`).
- Hardcoded English "· Rare" suffix on the foil pile label moved out of CSS into the JS that sets the label text. New `draw.foil.rare` key in en/fr/de/it/es (singular form, distinct from the plural collection filter).
- Update banner now sits at `bottom: 94px + safe-area` to match the sync banner, so it stops covering the rightmost bottom-nav links.
- Collection toolbar and grid no longer add a second 14px horizontal padding on top of `.screen`'s 18px, so the counter / chips / grid align with the screen title.

### MEDIUM

- Dead `.home-nav` / `.btn-nav` block removed (no template emitted either class).
- `admin.css` deduplicated against `style.css` (`pile-badge.home`, `pile-badge.outdoor`, `field-inline`).
- Hardcoded `'Fraunces'` / `'Inter'` stacks replaced by `var(--font-display)` / `var(--font)` in three places.
- `.action-tag.banned` background switched from a stale literal rgba to `color-mix(in srgb, var(--danger) 18%, transparent)` so the badge fill stays in sync with `--danger`.
- Boot skeleton is now transparent over the body gradient (no more flat-fill flash on dismiss) and the logo pulse / bar sweep share a 1.2s cadence so they breathe together.
- Card back-frame inset aligned to 14px to match the front-frame, so the flip lands on the same crop.
- Modal padding made uniform (22px) so the footer buttons stop crowding the right wall.
- List mask-image bottom fade halved from 16px to 8px so action-tags on the last row stay readable above the bottom nav.

### LOW

- Locked-foil tile halo radius bumped 13px → 14px to wrap the 12px tile flush given its `inset: -2px`.
- Base `.heart-icon` drop-shadow removed (the `.card-back-crest .heart-icon` override already carries the bright version where it belongs); the small in-card divider ornament no longer bleeds into the parchment.
- Redundant `font-size: 0.92rem` on `.draw-actions #action-redraw` dropped.
- `.btn:hover { filter: brightness(1.05) }` dropped; the per-variant shadow boost is enough.

### Wrap-up

- SW cache key bumped v31 → v32.
- `CHANGELOG.md` `[Unreleased]` updated.

## Expected behaviours

- Reveal a foil card: the gold halo pulses visibly around the rim (was clipped to nothing before).
- Reveal a foil card in any locale: the small label under the card shows "Home · Rare" / "Maison · Rare" / "Casa · Rara" / "Casa · Selten" / etc., not English "· Rare" everywhere.
- Trigger a service-worker update: the "A new version is available" banner sits above the bottom nav with the Reload button reachable.
- Visit `/#/collection`: counter, filters and grid align with the back arrow and screen title; no horizontal step.
- Flip a card: the gold dashed liner on the back and the same liner on the front sit at the same inset.
- Open any confirmation modal: padding is symmetric, footer buttons no longer crammed against the right edge.
- Reload the app cold: the boot skeleton dissolves into the gradient without a one-frame flat-color flash.
- Hover any button (desktop): only the per-variant shadow lifts; no overall brightness wash.

## Test plan

- [ ] Visual diff the foil card before/after (Home and Outdoor variants).
- [ ] Switch the five locales on the draw screen with a foil card up.
- [ ] Simulate a SW update locally (bump v32 → v33 and reload) and verify the update banner.
- [ ] Walk through Collection on a 360-wide phone viewport.
- [ ] Open a modal and check the button row sits centred on the bottom rhythm.
- [ ] Cold-reload the SPA and the admin shell.