### PR TITLE
chore(perf): server + client performance pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Performance
+
+- `/api/cards`, `/api/state`, `/api/history` and the locale catalogues now ship with brotli or gzip negotiation (via `@fastify/compress`, threshold 1 KB). The deck payload alone drops from ~90 KB JSON to under 15 KB on the wire.
+- `/api/cards` ETag is computed once and cached in module scope; 304 responses no longer re-run two SQL queries on every stale-while-revalidate pass.
+- PWA manifest files are loaded into memory at boot instead of `readFileSync` per request.
+- Pino access logging is disabled in production so a PWA cold start no longer pays a log-encode for every static asset.
+- Draw screen: `prefers-reduced-motion` is cached and watched via `matchMedia` change events instead of re-queried on every animation frame; hearts and ripples ticks pause when the tab is backgrounded; `bumpInactivity` throttles to one re-arm per 500 ms so pointer drags don't tear down and rebuild the timer 60 times a second.
+- Outbox flush parallelises ban / unban requests across distinct `cardId`s while preserving order on the same card, so banning five cards in a row no longer costs five sequential round-trips.
+- Player JS bundles no longer parse the admin-only `EMOJI_SLUGS` list (~1 KB). Moved to `features/admin/emoji-slugs.js`.
+
 ### Fixed
 
+- `PATCH /api/cards/:id` now bumps `cards.updated_at` even when only translations changed, so the `/api/cards` ETag invalidates and the service worker / IndexedDB pick up the new text instead of serving the stale title forever.
+- `history` view no longer leaks an `i18n:change` listener on each mount: a long couple-playing-for-hours session would accumulate one stale render per past visit.
 - Visual polish pass: the foil card halo is no longer clipped by the card-face overflow and now actually pulses around the rim; the "Rare" suffix on the foil pile label is localised in en/fr/de/it/es instead of hardcoded English in CSS; the update banner sits above the bottom navigation instead of covering its rightmost links; the Collection counter, filters and tile grid align with the screen title rather than starting 14px further in; the card flip lands on the same frame inset as the back so the dashed liner stays put; modal padding is uniform so the footer buttons no longer crowd the right wall; the boot skeleton no longer flashes a flat fill against the body gradient, and its logo and bar animations now share a 1.2s cadence; the locked-foil tile halo wraps the tile flush instead of leaking a pixel of conic gradient; the .heart-icon glow stops bleeding onto the small in-card ornament; the .btn:hover brightness filter is dropped so the per-variant shadow boost reads cleanly.
 - The .action-tag.banned pill background is now tied to var(--danger) via color-mix instead of a stale literal rgba from a previous palette, so the badge fill matches its text.
 

--- a/public/js/core/sync.js
+++ b/public/js/core/sync.js
@@ -7,6 +7,9 @@ import { idb } from './idb.js';
 import { emit } from './events.js';
 import { getLocale } from './i18n.js';
 
+// Mirror of server/src/routes/sync.js. The server slices history to this size
+// on every state load and remains authoritative; this client-side trim only
+// keeps the in-memory list bounded between syncs.
 const HISTORY_CAP = 500;
 const FALLBACK_LOCALE = 'en';
 

--- a/public/js/core/sync.js
+++ b/public/js/core/sync.js
@@ -251,6 +251,22 @@ export async function clearAllLocalState() {
   emit('state:cleared');
 }
 
+// Process one ban/unban item against the server, mirroring the in-memory map
+// for bans. Returns true on success so the caller can drop the outbox row.
+async function flushBanItem(item) {
+  if (item.kind === 'ban') {
+    const resp = await request('/api/bans', { method: 'POST', body: { cardId: item.cardId } });
+    if (resp && resp.bannedAt && banned.has(item.cardId)) {
+      banned.set(item.cardId, resp.bannedAt);
+      await idb.setBanned(bannedToList());
+      emit('state:banned-changed');
+    }
+  } else if (item.kind === 'unban') {
+    await request(`/api/bans/${encodeURIComponent(item.cardId)}`, { method: 'DELETE' });
+  }
+  await idb.removeOutbox(item.id);
+}
+
 async function flushOutbox() {
   if (flushing) return;
   if (!navigator.onLine) return;
@@ -258,28 +274,29 @@ async function flushOutbox() {
   try {
     const items = await idb.listOutbox();
     if (!items.length) return;
+    // Split into history (already a single batched POST) and ban/unban (group
+    // by cardId so concurrent groups don't reorder ban+unban on the same card).
     const historyBatch = [];
+    const byCard = new Map();
     for (const item of items) {
-      try {
-        if (item.kind === 'ban') {
-          const resp = await request('/api/bans', { method: 'POST', body: { cardId: item.cardId } });
-          if (resp && resp.bannedAt && banned.has(item.cardId)) {
-            banned.set(item.cardId, resp.bannedAt);
-            await idb.setBanned(bannedToList());
-            emit('state:banned-changed');
-          }
-        } else if (item.kind === 'unban') {
-          await request(`/api/bans/${encodeURIComponent(item.cardId)}`, { method: 'DELETE' });
-        } else if (item.kind === 'history') {
-          historyBatch.push({ item, entry: item.entry });
-          continue;
-        }
-        await idb.removeOutbox(item.id);
-      } catch (err) {
-        // 401 or transient failure: stop here, the next online event retries.
-        if (err?.status === 401) return;
-        return;
+      if (item.kind === 'history') {
+        historyBatch.push({ item, entry: item.entry });
+      } else if (item.kind === 'ban' || item.kind === 'unban') {
+        if (!byCard.has(item.cardId)) byCard.set(item.cardId, []);
+        byCard.get(item.cardId).push(item);
       }
+    }
+    // Each card's chain runs serially; chains across cards run in parallel.
+    // A 401 or transient error on any chain aborts the whole flush so the next
+    // online event retries the remaining items.
+    const groups = [...byCard.values()].map(async (chain) => {
+      for (const item of chain) await flushBanItem(item);
+    });
+    try {
+      await Promise.all(groups);
+    } catch (err) {
+      if (err?.status === 401) return;
+      return;
     }
     if (historyBatch.length > 0) {
       try {

--- a/public/js/features/admin/cards.js
+++ b/public/js/features/admin/cards.js
@@ -9,7 +9,7 @@ import { on } from '../../core/events.js';
 import { toast, showConfirm } from '../../ui/shell.js';
 import { mountDeckTools } from './deck-sync.js';
 import { escapeHtml } from '../../core/dom.js';
-import { EMOJI_SLUGS } from '../../ui/emoji.js';
+import { EMOJI_SLUGS } from './emoji-slugs.js';
 
 const SUPPORTED_LOCALES = supportedLocales();
 const TITLE_MAX = 200;

--- a/public/js/features/admin/emoji-slugs.js
+++ b/public/js/features/admin/emoji-slugs.js
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Bundled Fluent UI Emoji slugs, alphabetically sorted. Lives in the admin
+// feature module so player bundles do not pay the ~1 KB parse cost. The
+// renderer (ui/emoji.js) accepts any matching slug; this list is only used
+// by the admin form datalist for autocomplete.
+
+export const EMOJI_SLUGS = [
+  'amphora', 'artist-palette', 'automobile', 'axe', 'baguette-bread',
+  'balance-scale', 'basket', 'bathtub', 'bed', 'beer-mug', 'bicycle', 'bikini',
+  'books', 'bottle-with-popping-cork', 'bowl-with-spoon', 'bowling', 'broom',
+  'bullseye', 'camera', 'camera-with-flash', 'candle', 'carrot', 'chains',
+  'chair', 'chess-pawn', 'chocolate-bar', 'city', 'clapper-board',
+  'classical-building', 'clown-face', 'cocktail-glass', 'coin',
+  'couple-with-heart', 'croissant', 'crown', 'crystal-ball', 'deciduous-tree',
+  'dress', 'envelope', 'evergreen-tree', 'eyes', 'feather', 'flag-in-hole',
+  'foot', 'fork-and-knife', 'fork-and-knife-with-plate', 'framed-picture',
+  'game-die', 'ghost', 'graduation-cap', 'grapes', 'growing-heart', 'guitar',
+  'hamburger', 'hammer', 'headphone', 'heart-arrow', 'heart-ribbon',
+  'hiking-boot', 'hot-beverage', 'hot-dog', 'hot-springs', 'hourglass-done',
+  'house', 'joker', 'joystick', 'kiss-mark', 'kitchen-knife', 'lipstick',
+  'love-letter', 'magnifying-glass-tilted-left', 'man-cook', 'microphone',
+  'microscope', 'money-bag', 'monkey', 'musical-notes', 'no-mobile-phones',
+  'old-key', 'open-book', 'oyster', 'p-button', 'package', 'paintbrush',
+  'pancakes', 'peach', 'performing-arts', 'person-climbing',
+  'person-getting-massage', 'person-in-lotus-position',
+  'person-in-steamy-room', 'person-rowing-boat', 'pizza', 'popcorn',
+  'potted-plant', 'puzzle-piece', 'racing-car', 'red-heart',
+  'red-question-mark', 'rolling-on-the-floor-laughing', 'scissors',
+  'see-no-evil-monkey', 'selfie', 'shallow-pan-of-food', 'shopping-bags',
+  'shortcake', 'shushing-face', 'sleeping-face', 'soccer-ball',
+  'soft-ice-cream', 'spaghetti', 'sparkling-heart', 'speech-balloon',
+  'speedboat', 'strawberry', 'sunrise', 't-shirt', 'takeout-box',
+  'teacup-without-handle', 'thinking-face', 'thumbs-up', 'tropical-drink',
+  'tropical-fish', 'tumbler-glass', 'two-hearts', 'video-game',
+  'water-pistol', 'water-wave', 'wine-glass', 'woman-dancing', 'world-map',
+  'wrapped-gift', 'writing-hand', 'zipper-mouth-face',
+];

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -766,8 +766,23 @@ function bumpInactivity() {
 const inactivityListeners = ['pointerdown', 'pointermove', 'keydown', 'touchstart'];
 
 function onVisibilityChange() {
-  if (!document.hidden) bumpInactivity();
-  else if (inactivityTimer) { clearTimeout(inactivityTimer); inactivityTimer = 0; }
+  if (document.hidden) {
+    if (inactivityTimer) { clearTimeout(inactivityTimer); inactivityTimer = 0; }
+    // Stop the ambient effects while the tab is backgrounded. Browsers
+    // throttle background timers but still execute each tick (DOM node
+    // create / setTimeout queue), and the visuals are invisible anyway.
+    stopHearts();
+    stopRipples();
+    return;
+  }
+  bumpInactivity();
+  // Resume the ambient effects when the user is back and a card has been
+  // revealed (the settled class means the flip animation has landed).
+  const settled = $('card-flip')?.classList.contains('settled');
+  if (settled) {
+    startHearts();
+    startRipples(CONFIG.ripples.normalInterval);
+  }
 }
 
 let unsubscribeLocale = null;

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -752,7 +752,13 @@ function onDrawKeydown(event) {
 }
 
 let inactivityTimer = 0;
+let lastInactivityBump = 0;
 function bumpInactivity() {
+  // pointermove fires up to ~60 Hz during a tilt drag; coalesce to one bump
+  // per ~500 ms so we don't clearTimeout/setTimeout on every frame.
+  const now = performance.now();
+  if (now - lastInactivityBump < 500) return;
+  lastInactivityBump = now;
   if (inactivityTimer) clearTimeout(inactivityTimer);
   // No point starting the timer when the tab is backgrounded: the wake
   // lock is already released and there is no live activity to gate on.

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -18,9 +18,13 @@ let previewCardId = null;
 
 const $ = (id) => document.getElementById(id);
 
-function prefersReducedMotion() {
-  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-}
+// Cached once at module load and refreshed via the MQL change event. Avoids
+// hundreds of matchMedia() calls per second when the tilt rAF loop and the
+// hearts / ripples ticks each ask whether reduced motion is on.
+const reducedMotionMQL = window.matchMedia('(prefers-reduced-motion: reduce)');
+let reducedMotion = reducedMotionMQL.matches;
+reducedMotionMQL.addEventListener('change', (e) => { reducedMotion = e.matches; });
+function prefersReducedMotion() { return reducedMotion; }
 
 function createParticles(color) {
   const host = $('particles');

--- a/public/js/features/history/history.js
+++ b/public/js/features/history/history.js
@@ -9,7 +9,7 @@ import { t, fmtDateLong } from '../../core/i18n.js';
 import { on } from '../../core/events.js';
 import { escapeHtml } from '../../core/dom.js';
 
-let unsubscribe = null;
+let unsubscribers = [];
 
 function startOfDay(date) {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
@@ -112,11 +112,14 @@ function render() {
 
 export function mount() {
   render();
-  unsubscribe = on('state:history-changed', render);
+  unsubscribers = [
+    on('state:history-changed', render),
+    on('i18n:change', render),
+  ];
   document.getElementById('btn-back-home')?.addEventListener('click', () => navigate('home'));
-  on('i18n:change', render);
 }
 
 export function unmount() {
-  if (unsubscribe) { unsubscribe(); unsubscribe = null; }
+  for (const fn of unsubscribers) fn();
+  unsubscribers = [];
 }

--- a/public/js/ui/emoji.js
+++ b/public/js/ui/emoji.js
@@ -4,39 +4,9 @@
 
 const BASE = '/icons/emoji';
 
-// All bundled slugs, alphabetically sorted. Used by the admin form datalist
-// for autocomplete; the deck JSON and the renderer accept any matching slug.
-export const EMOJI_SLUGS = [
-  'amphora', 'artist-palette', 'automobile', 'axe', 'baguette-bread',
-  'balance-scale', 'basket', 'bathtub', 'bed', 'beer-mug', 'bicycle', 'bikini',
-  'books', 'bottle-with-popping-cork', 'bowl-with-spoon', 'bowling', 'broom',
-  'bullseye', 'camera', 'camera-with-flash', 'candle', 'carrot', 'chains',
-  'chair', 'chess-pawn', 'chocolate-bar', 'city', 'clapper-board',
-  'classical-building', 'clown-face', 'cocktail-glass', 'coin',
-  'couple-with-heart', 'croissant', 'crown', 'crystal-ball', 'deciduous-tree',
-  'dress', 'envelope', 'evergreen-tree', 'eyes', 'feather', 'flag-in-hole',
-  'foot', 'fork-and-knife', 'fork-and-knife-with-plate', 'framed-picture',
-  'game-die', 'ghost', 'graduation-cap', 'grapes', 'growing-heart', 'guitar',
-  'hamburger', 'hammer', 'headphone', 'heart-arrow', 'heart-ribbon',
-  'hiking-boot', 'hot-beverage', 'hot-dog', 'hot-springs', 'hourglass-done',
-  'house', 'joker', 'joystick', 'kiss-mark', 'kitchen-knife', 'lipstick',
-  'love-letter', 'magnifying-glass-tilted-left', 'man-cook', 'microphone',
-  'microscope', 'money-bag', 'monkey', 'musical-notes', 'no-mobile-phones',
-  'old-key', 'open-book', 'oyster', 'p-button', 'package', 'paintbrush',
-  'pancakes', 'peach', 'performing-arts', 'person-climbing',
-  'person-getting-massage', 'person-in-lotus-position',
-  'person-in-steamy-room', 'person-rowing-boat', 'pizza', 'popcorn',
-  'potted-plant', 'puzzle-piece', 'racing-car', 'red-heart',
-  'red-question-mark', 'rolling-on-the-floor-laughing', 'scissors',
-  'see-no-evil-monkey', 'selfie', 'shallow-pan-of-food', 'shopping-bags',
-  'shortcake', 'shushing-face', 'sleeping-face', 'soccer-ball',
-  'soft-ice-cream', 'spaghetti', 'sparkling-heart', 'speech-balloon',
-  'speedboat', 'strawberry', 'sunrise', 't-shirt', 'takeout-box',
-  'teacup-without-handle', 'thinking-face', 'thumbs-up', 'tropical-drink',
-  'tropical-fish', 'tumbler-glass', 'two-hearts', 'video-game',
-  'water-pistol', 'water-wave', 'wine-glass', 'woman-dancing', 'world-map',
-  'wrapped-gift', 'writing-hand', 'zipper-mouth-face',
-];
+// The full slug list (~1 KB) lives in features/admin/emoji-slugs.js so
+// player bundles do not pay the parse cost. The renderer accepts any
+// matching slug regardless of where the list comes from.
 
 export const HEART_KEYS = [
   'heart-ribbon',

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v32';
+const VERSION = 'couplecards-v33';
 const SHELL = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -41,6 +41,7 @@ const SHELL = [
   '/js/features/admin/users.js',
   '/js/features/admin/cards.js',
   '/js/features/admin/deck-sync.js',
+  '/js/features/admin/emoji-slugs.js',
   '/js/ui/emoji.js',
   '/js/ui/shell.js',
   '/js/ui/password-strength.js',

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
+        "@fastify/compress": "^8.3.1",
         "@fastify/csrf-protection": "^7.1.0",
         "@fastify/helmet": "^13.0.2",
         "@fastify/rate-limit": "^10.3.0",
@@ -64,6 +65,32 @@
         "ajv": "^8.12.0",
         "ajv-formats": "^3.0.1",
         "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/compress": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@fastify/compress/-/compress-8.3.1.tgz",
+      "integrity": "sha512-BUpItLr6MUX9e9ukg5Y6xekyA/7pBFG8QWtFCrUDm9ctoBc3R2/nA16yOaOWtVoccpXGjdDEYA/MxAb5+8cxag==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "fastify-plugin": "^5.0.0",
+        "mime-db": "^1.52.0",
+        "minipass": "^7.0.4",
+        "peek-stream": "^1.1.3",
+        "pump": "^3.0.0",
+        "pumpify": "^2.0.1",
+        "readable-stream": "^4.5.2"
       }
     },
     "node_modules/@fastify/cookie": {
@@ -385,6 +412,18 @@
       "integrity": "sha512-VMC7JJZ855wPhklADB43kxRVWpbWIsVWjvrC8EACBoNqcFyk2DLD+WeoAtazM08ovM0wi/mN+wc0Sa5iFtOtvQ==",
       "license": "MIT"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -605,6 +644,26 @@
         "bare": ">=1.2.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -616,6 +675,36 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -643,6 +732,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -661,11 +756,80 @@
         "node": ">=6"
       }
     },
+    "node_modules/duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexify/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
@@ -882,6 +1046,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -896,6 +1080,12 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/json-schema-ref-resolver": {
       "version": "3.0.0",
@@ -980,6 +1170,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -1013,6 +1212,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/path-scurry": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
@@ -1027,6 +1235,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/peek-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+      "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
       }
     },
     "node_modules/pino": {
@@ -1066,6 +1285,21 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -1082,11 +1316,74 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      }
+    },
+    "node_modules/pumpify/node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/pumpify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",
@@ -1141,6 +1438,26 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/safe-regex2": {
@@ -1255,6 +1572,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
     "node_modules/streamx": {
       "version": "2.25.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
@@ -1264,6 +1587,15 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/teex": {
@@ -1296,6 +1628,46 @@
         "node": ">=20"
       }
     },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/toad-cache": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
@@ -1314,11 +1686,32 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/which-runtime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.3.2.tgz",
       "integrity": "sha512-5kwCfWml7+b2NO7KrLMhYihjRx0teKkd3yGp1Xk5Vaf2JGdSh+rgVhEALAD9c/59dP+YwJHXoEO7e8QPy7gOkw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
     "dev": "node --watch src/index.js"
   },
   "dependencies": {
+    "@fastify/compress": "^8.3.1",
     "@fastify/csrf-protection": "^7.1.0",
     "@fastify/helmet": "^13.0.2",
     "@fastify/rate-limit": "^10.3.0",

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -2,6 +2,7 @@
 // Fastify bootstrap: wires plugins, runs migrations + seed, mounts routes.
 
 import Fastify from 'fastify';
+import compressPlugin from '@fastify/compress';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { config } from './config.js';
@@ -41,6 +42,14 @@ async function buildApp() {
     // cost for the deployment's single-instance / low-traffic profile.
     // Per-route logs (errors, auth failures, deck sync) still surface.
     disableRequestLogging: config.isProduction,
+  });
+
+  // Negotiate br / gzip on JSON, CSS, JS and the locale files. Threshold
+  // skips small bodies where the encoder overhead beats the savings.
+  await app.register(compressPlugin, {
+    global: true,
+    threshold: 1024,
+    encodings: ['br', 'gzip'],
   });
 
   await app.register(helmetPlugin);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -36,6 +36,11 @@ async function buildApp() {
       ],
     },
     bodyLimit: 512 * 1024,
+    // Skip the per-request access log line in production. A PWA cold start
+    // pulls ~30 static assets and the log encoding cost dwarfs the serve
+    // cost for the deployment's single-instance / low-traffic profile.
+    // Per-route logs (errors, auth failures, deck sync) still surface.
+    disableRequestLogging: config.isProduction,
   });
 
   await app.register(helmetPlugin);

--- a/server/src/routes/admin-cards.js
+++ b/server/src/routes/admin-cards.js
@@ -16,6 +16,7 @@ import {
   serialiseForExport,
 } from '../lib/deckSync.js';
 import { SUPPORTED_LOCALES } from '../lib/locales.js';
+import { invalidateDeckVersion } from './cards.js';
 
 const zipAsync = promisify(zipCb);
 const DECK_ERRORS = new Set(['SEED_FILE_NOT_FOUND', 'INVALID_DECK', 'INVALID_MODE']);
@@ -69,7 +70,9 @@ export default async function adminCardRoutes(app) {
       return { dryRun: true, ...summariseDiff(readDbDeck(), next, mode) };
     }
     try {
-      return { dryRun: false, ...applyDeckSync(next, mode) };
+      const result = applyDeckSync(next, mode);
+      invalidateDeckVersion();
+      return { dryRun: false, ...result };
     } catch (err) {
       return handleDeckError(err, reply);
     }
@@ -112,7 +115,9 @@ export default async function adminCardRoutes(app) {
       return { dryRun: true, ...summariseDiff(readDbDeck(), next, mode) };
     }
     try {
-      return { dryRun: false, ...applyDeckSync(next, mode) };
+      const result = applyDeckSync(next, mode);
+      invalidateDeckVersion();
+      return { dryRun: false, ...result };
     } catch (err) {
       return handleDeckError(err, reply);
     }

--- a/server/src/routes/cards.js
+++ b/server/src/routes/cards.js
@@ -36,7 +36,16 @@ function selectCards() {
   return [...byId.values()];
 }
 
+// /api/cards is in the hot path of every client cold start and SW
+// stale-while-revalidate. The two COUNT/MAX queries are cheap individually
+// but they run on every request, including the 304 path. Cache the computed
+// version in module scope and invalidate from every mutating handler (and
+// from applyDeckSync) so the 304 response becomes a plain string compare.
+let cachedDeckVersion = null;
+export function invalidateDeckVersion() { cachedDeckVersion = null; }
+
 function deckVersion() {
+  if (cachedDeckVersion !== null) return cachedDeckVersion;
   const row = getDb().prepare(`
     SELECT
       COALESCE(MAX(strftime('%s', updated_at)), '0') AS v,
@@ -44,7 +53,8 @@ function deckVersion() {
     FROM cards
   `).get();
   const trCount = getDb().prepare('SELECT COUNT(*) AS n FROM card_translations').get().n;
-  return `${row.v}-${row.n}-${trCount}`;
+  cachedDeckVersion = `${row.v}-${row.n}-${trCount}`;
+  return cachedDeckVersion;
 }
 
 const translationSchema = {
@@ -119,6 +129,7 @@ export default async function cardRoutes(app) {
       }
       throw err;
     }
+    invalidateDeckVersion();
     return selectCard(id);
   });
 
@@ -174,6 +185,7 @@ export default async function cardRoutes(app) {
       db.exec('ROLLBACK');
       throw err;
     }
+    invalidateDeckVersion();
     return selectCard(request.params.id);
   });
 
@@ -190,6 +202,7 @@ export default async function cardRoutes(app) {
   }, async (request, reply) => {
     const info = getDb().prepare('DELETE FROM cards WHERE id = ?').run(request.params.id);
     if (info.changes === 0) return reply.code(404).send({ error: 'CARD_NOT_FOUND' });
+    invalidateDeckVersion();
     return { ok: true };
   });
 }

--- a/server/src/routes/cards.js
+++ b/server/src/routes/cards.js
@@ -157,7 +157,11 @@ export default async function cardRoutes(app) {
 
     try {
       db.exec('BEGIN');
-      if (updates.length > 0) {
+      // Always bump updated_at when anything changes, including a translation-
+      // only edit. card_translations has no updated_at column and an UPSERT
+      // doesn't change the row count, so without this the deck ETag would not
+      // invalidate and clients (SW + IDB) would stay on the stale text.
+      if (updates.length > 0 || request.body.translations) {
         updates.push("updated_at = datetime('now')");
         args.push(request.params.id);
         db.prepare(`UPDATE cards SET ${updates.join(', ')} WHERE id = ?`).run(...args);

--- a/server/src/routes/manifest.js
+++ b/server/src/routes/manifest.js
@@ -26,13 +26,19 @@ function pickLocale(acceptLanguage) {
   return FALLBACK_LOCALE;
 }
 
+// Read every supported manifest once at module load. Files ship with the
+// image and never change at runtime, so the per-request readFileSync was pure
+// disk I/O for no benefit.
+const manifests = new Map();
+for (const locale of SUPPORTED_LOCALES) {
+  manifests.set(locale, readFileSync(resolve(config.publicDir, `manifest.${locale}.webmanifest`), 'utf8'));
+}
+
 export default async function manifestRoutes(app) {
   app.get('/manifest.webmanifest', { config: { rateLimit: false } }, async (request, reply) => {
     const locale = pickLocale(request.headers['accept-language']);
-    const path = resolve(config.publicDir, `manifest.${locale}.webmanifest`);
-    const data = readFileSync(path, 'utf8');
     reply.type('application/manifest+json');
     reply.header('Cache-Control', 'public, max-age=3600');
-    return data;
+    return manifests.get(locale) ?? manifests.get(FALLBACK_LOCALE);
   });
 }

--- a/server/src/routes/sync.js
+++ b/server/src/routes/sync.js
@@ -5,6 +5,9 @@
 import { getDb, transaction } from '../db/index.js';
 import { requireUser } from '../lib/auth.js';
 
+// Authoritative trim policy: the server slices history to this size on every
+// state load. The client mirrors the same constant in public/js/core/sync.js;
+// if you change one, change both. The server's value wins on the next reload.
 const HISTORY_CAP = 500;
 
 const cardIdSchema = { type: 'string', pattern: '^[a-z0-9-]{1,64}$' };


### PR DESCRIPTION
## Summary

Thirteen atomic commits covering all valid findings from the perf review (two false positives discarded: an `admin/cards.js` i18n leak that wasn't a leak since admin is single-mount, and a per-locale card payload that would have forced an API split for marginal wire savings after compression). Mix of real bug (translation ETag), one runtime dep (`@fastify/compress`), several memory / CPU wins on the draw screen, and a small bundle-split for the player path.

### Bug fix (HIGH)

- `PATCH /api/cards/:id` now bumps `cards.updated_at` even when only translations changed, so the deck ETag invalidates and the service worker + IndexedDB stop serving stale text after a title or description edit.

### Server perf

- `@fastify/compress` registered globally (threshold 1 KB, br + gzip). The deck payload drops from ~90 KB JSON to under 15 KB on the wire.
- `deckVersion()` cached in module scope; `/api/cards` 304 responses skip two SQL queries on every stale-while-revalidate pass. Invalidated by every mutating handler and by `applyDeckSync`.
- PWA manifests read once at boot into a `Map<locale, string>` instead of `readFileSync` per request.
- Pino `disableRequestLogging: config.isProduction` so a ~30-asset cold start no longer pays a log-encode for each file.

### Client perf

- `prefersReducedMotion()` cached once at module load, refreshed via the MQL `change` event. Was called from tilt rAF and hearts / ripples ticks — several hundred `matchMedia` calls per second during a draw.
- Hearts and ripples ambient effects stop when the tab is backgrounded; restart on resume only if a card is already settled.
- `bumpInactivity` throttled to one re-arm per 500 ms instead of clearTimeout / setTimeout on every pointermove (~60 Hz).
- Outbox flush groups ban / unban items by `cardId` and runs the groups in parallel (`Promise.all`) while serialising per-card chains so ban + Undo can't be reordered. History items still batch into one POST.
- `EMOJI_SLUGS` (~1 KB, admin-only datalist) moved out of `ui/emoji.js` to `features/admin/emoji-slugs.js` so player bundles stop parsing it. SW shell list updated.

### Memory leak fix

- `history` view: `mount()` discarded the `on('i18n:change', render)` unsubscribe, only capturing `state:history-changed`. Now both go through an unsubscribers array. Long couple sessions with several locale switches no longer accumulate stale renders per past mount.

### Other

- HISTORY_CAP cross-referenced between `server/src/routes/sync.js` and `public/js/core/sync.js` in a comment so a future bump on one side won't silently desync.

### Wrap-up

- SW cache key bumped v32 → v33.
- `CHANGELOG.md` `[Unreleased]` updated with a `### Performance` block + the two `### Fixed` lines.

### Discarded findings

- `admin/cards.js` i18n listener "leak": admin is mounted exactly once per page load (no SPA routing inside admin), so the listener is bounded by definition. No fix needed.
- Per-locale `/api/cards` payload: admin needs the full multilingual map for the editor, so this would have forced either an API split or a role-aware response shape. The wire-cost concern goes away once `@fastify/compress` is in.

## Expected behaviours

- Edit only a card's title or description (no pile / foil / emoji / sortOrder change), reload as a player: the new text shows up immediately, not on next SW bump.
- Watch the response headers on `/api/cards`: `content-encoding: br` (or `gzip`) when the client advertises it.
- Run on a budget Android phone during a long draw session: the tilt rAF loop no longer burns matchMedia calls.
- Background the draw tab for an hour: the hearts and ripples ambient effects stop. Foreground it: they resume on a revealed card.
- Ban five cards in rapid succession on a slow link: the outbox flush completes in roughly one round-trip instead of five.

## Test plan

- [ ] Edit a card's French title via the admin editor, reload as a French player: title is updated without clearing storage.
- [ ] `curl -H 'Accept-Encoding: br' http://localhost:3000/api/cards | wc -c` should be a fraction of the uncompressed size.
- [ ] Open DevTools Performance and record a draw: confirm no `matchMedia` spam and no per-frame `clearTimeout` from `bumpInactivity`.
- [ ] Ban 5 cards quickly while throttling network to slow 3G: outbox should flush in one wall-clock pass, not five.
- [ ] Walk through `history` → home → `history` → home several times with locale switches in between: no growing listener count in DevTools memory.