### PR TITLE
chore: refresh docs and trim two stale comments

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -72,10 +72,10 @@ The **Sync from the files** button reads every `cards.<locale>.json` present und
 
 The dialog offers two modes.
 
+- **Add and update** (default). New cards found in the files are inserted, existing cards with the same ID have their text updated, and any card present only in the database is kept as is. Use this mode when the admin has added bespoke cards through the UI that should survive.
 - **Full mirror.** The database becomes an exact copy of the file set. Cards that are present in the database but missing from every file are deleted, along with the ban rows that pointed to them. Use this mode when the files are the authoritative source.
-- **Add and update.** New cards found in the files are inserted, existing cards with the same ID have their text updated, and any card present only in the database is kept as is. Use this mode when the admin has added bespoke cards through the UI that should survive.
 
-The dialog requires a preview before the **Apply sync** button becomes active. The preview shows how many cards will be added, updated, removed or left unchanged, which makes accidental deletions impossible to miss. A **Download a backup** shortcut sits in the same dialog so the current deck can be saved in one click before applying.
+The dialog requires a preview before the **Apply sync** button becomes active. The preview shows how many cards will be added, updated, removed or left unchanged, which makes accidental deletions impossible to miss. When the preview reports any removal the **Apply sync** button turns red so a destructive operation is hard to fire by reflex. A **Download a backup** shortcut sits in the same dialog so the current deck can be saved in one click before applying.
 
 ### Import a backup
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,8 +32,7 @@ couplecards/
 │   ├── css/, fonts/, icons/, locales/, vendor/
 │   └── sw.js                     Service Worker
 ├── data/
-│   ├── cards.en.json             English translations, loaded at first-run seed
-│   └── cards.fr.json             French translations, loaded at first-run seed
+│   └── cards.<locale>.json       One file per supported locale (en, fr, de, it, es), loaded at first-run seed
 ├── scripts/                      build-time helpers (vendor bundle, SPDX retrofit)
 ├── deploy/                       reverse proxy presets for Caddy, Traefik and nginx
 ├── docs/                         you are here

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@ couplecards/
 │   ├── js/
 │   │   ├── app.js, login.js, admin.js       page entry points
 │   │   ├── core/                 api, auth, events, i18n, idb, router, sync
-│   │   ├── features/             home, deck, history, collection, settings, rules, admin, auth
+│   │   ├── features/             home, deck, history, collection, settings, rules, admin
 │   │   └── ui/                   shell, emoji, password-strength, sound
 │   ├── css/, fonts/, icons/, locales/, vendor/
 │   └── sw.js                     Service Worker

--- a/docs/security.md
+++ b/docs/security.md
@@ -70,9 +70,9 @@ The optional `demo` account, enabled with `ENABLE_DEMO_ACCOUNT=1`, is a delibera
 
 ## Logging
 
-- Fastify's Pino logger runs at `info` in production.
+- Fastify's Pino logger runs at `info` in production and emits only error and per-route lines. The per-request access log line is disabled in production (a PWA cold start pulls ~30 static assets and the log encoding cost dominated the serve cost for the deployment's single-instance profile).
 - Password fields (`req.body.password`, `req.body.newPassword`, `req.body.currentPassword`) and the generated initial password are redacted from every log line.
-- The login route increments a per-user `failed_attempts` counter (used for lockout) but does not write a historical journal of authentication attempts. After a successful sign-in the counter is reset, so a compromised account leaves no in-app trace of when or from where the attacker connected. This is an explicit trade-off for the small-scale, two-person threat model the app targets. Operators who need an audit trail can mine the Pino access logs (timestamps, IP via Fastify's `request.ip`, `req.url`) shipped on stdout, or front the app with a reverse proxy that records its own access log.
+- The login route increments a per-user `failed_attempts` counter (used for lockout) but does not write a historical journal of authentication attempts. After a successful sign-in the counter is reset, so a compromised account leaves no in-app trace of when or from where the attacker connected. This is an explicit trade-off for the small-scale, two-person threat model the app targets. Operators who want an audit trail should front the app with a reverse proxy that records its own access log (every variant under [`deploy/`](../deploy/) does).
 
 ## Vulnerability disclosure
 

--- a/public/js/core/sync.js
+++ b/public/js/core/sync.js
@@ -254,8 +254,6 @@ export async function clearAllLocalState() {
   emit('state:cleared');
 }
 
-// Process one ban/unban item against the server, mirroring the in-memory map
-// for bans. Returns true on success so the caller can drop the outbox row.
 async function flushBanItem(item) {
   if (item.kind === 'ban') {
     const resp = await request('/api/bans', { method: 'POST', body: { cardId: item.cardId } });

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -44,8 +44,7 @@ async function buildApp() {
     disableRequestLogging: config.isProduction,
   });
 
-  // Negotiate br / gzip on JSON, CSS, JS and the locale files. Threshold
-  // skips small bodies where the encoder overhead beats the savings.
+  // Threshold below the smallest compressible response we serve.
   await app.register(compressPlugin, {
     global: true,
     threshold: 1024,


### PR DESCRIPTION
## Summary

Five small fixes to bring the docs in line with what the last five passes shipped, plus two recently-added comments that did not earn their lines.

### Docs

- `docs/security.md`: the Logging section pointed operators at the Pino access log as an audit-trail option, but the perf pass turned off per-request logging in production. Reword to say so and redirect operators to the reverse-proxy access log every `deploy/` variant already provides.
- `docs/architecture.md`: the `features/` directory list mentioned an `auth` subdirectory that has never existed (auth lives in `js/login.js` + `js/core/auth.js`).
- `docs/architecture.md`: the seed file block listed only `cards.en.json` and `cards.fr.json`, but we ship five locales (en, fr, de, it, es). Collapse to a glob so the list stays correct after the next locale.
- `docs/administration.md`: the deck sync section described both modes but did not say that **Add and update is the default**, nor that the **Apply button turns red** as soon as the preview reports rows that would be removed. Both came from the UX pass; document them.
- The deck stats line in `architecture.md` ("28 foil out of 142", "9.7% / 4.4%") was verified against the current FR seed file and is still accurate; no change there.

### Comments

- `public/js/core/sync.js`: `flushBanItem` carried a two-line comment that described what the function did and claimed a `Returns true on success` semantics the function never had. The name and body say enough; drop it.
- `server/src/index.js`: the `@fastify/compress` registration had a comment listing the MIME types the plugin negotiates (already implicit in the global registration) plus a generic threshold rationale. Replace with a one-liner about the threshold.

No runtime behaviour changes.

## Test plan

- [ ] Skim `docs/security.md`, `docs/architecture.md`, `docs/administration.md` rendered.
- [ ] Run the server locally and check that compression still works (`curl -H 'Accept-Encoding: br' http://localhost:3000/api/cards | wc -c`).