### PR TITLE
feat(login): floating emoji parallax behind the auth card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Login page gains a slow parallax of card emojis drifting behind the auth card. Sizes, blur and opacity are driven by a single per-icon depth value so the layers read as actual distance, and on desktop the cursor gently repels nearby icons. The whole effect is gated by `prefers-reduced-motion` so users who opted out see a static (and silent) background.
 - New "Delete all cards" button in the admin Deck maintenance toolbar, paired with a destructive confirmation. Lets an admin wipe the seeded deck before importing a custom one without round-tripping through the JSON files.
 - Server now logs a one-shot warning when it receives a plain-HTTP request while `COOKIE_SECURE=true`. Surfaces the silent-login-loop trap that hits self-hosters who copy the Docker image (which defaults `NODE_ENV=production` and therefore `COOKIE_SECURE=true`) into a LAN deploy and forget to flip the flag. The configuration reference doc was updated to describe the symptom upfront.
 

--- a/public/css/auth.css
+++ b/public/css/auth.css
@@ -51,3 +51,40 @@ body { font-family: var(--font); }
 .auth-form { display: flex; flex-direction: column; gap: 14px; }
 .auth-error:empty { display: none; }
 .auth-form .btn { margin-top: 6px; }
+
+.floating-bg {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+.auth-shell { position: relative; z-index: 1; }
+.floating-icon {
+  position: absolute;
+  opacity: var(--repel-opacity, var(--base-opacity, 0.25));
+  animation:
+    float-y var(--duration, 22s) ease-in-out infinite,
+    float-fade var(--duration, 22s) ease-in-out infinite;
+  filter: blur(var(--blur, 0.3px));
+  transition: opacity 0.3s ease;
+  will-change: transform, opacity;
+}
+.floating-icon > img {
+  display: block;
+  transform: translate3d(var(--repel-x, 0), var(--repel-y, 0), 0);
+  transition: transform 0.25s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@keyframes float-y {
+  0%, 100% { transform: translate3d(0, 0, 0) rotate(0deg); }
+  50%      { transform: translate3d(var(--drift, 0), -28px, 0) rotate(var(--rotate, 0deg)); }
+}
+@keyframes float-fade {
+  0%, 100% { opacity: var(--base-opacity, 0.25); }
+  50%      { opacity: calc(var(--base-opacity, 0.25) + 0.18); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .floating-icon { animation: none; }
+}

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -5,6 +5,7 @@
 import { login, me, changePassword, getPasswordPolicy } from './core/auth.js';
 import { initI18n, applyI18n, t, fmtDate } from './core/i18n.js';
 import { bindPasswordStrength } from './ui/password-strength.js';
+import { mountFloatingBackground } from './ui/floating-bg.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -79,6 +80,7 @@ function showChangeStep(user) {
 }
 
 async function init() {
+  mountFloatingBackground();
   const existing = await me();
   await initI18n(existing?.locale);
   applyI18n(document);

--- a/public/js/ui/floating-bg.js
+++ b/public/js/ui/floating-bg.js
@@ -47,8 +47,8 @@ export function mountFloatingBackground(count = 22) {
     item.style.zIndex = String(Math.round((1 - depth) * 10));
 
     const img = createEmojiImg(slug);
-    img.width = size;
-    img.height = size;
+    img.style.width = `${size}px`;
+    img.style.height = `${size}px`;
     item.appendChild(img);
     wrap.appendChild(item);
     items.push(item);

--- a/public/js/ui/floating-bg.js
+++ b/public/js/ui/floating-bg.js
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// Parallax of emojis behind the auth card. Single depth value per icon drives size/blur/opacity together.
+
+import { createEmojiImg } from './emoji.js';
+
+const SLUGS = [
+  'red-heart', 'growing-heart', 'sparkling-heart', 'two-hearts',
+  'heart-arrow', 'heart-ribbon', 'kiss-mark', 'couple-with-heart',
+  'love-letter', 'bottle-with-popping-cork', 'cocktail-glass',
+  'popcorn', 'shortcake', 'guitar', 'musical-notes', 'soccer-ball',
+  'hiking-boot', 'crystal-ball', 'game-die',
+];
+
+let mounted = false;
+
+export function mountFloatingBackground(count = 22) {
+  if (mounted) return;
+  mounted = true;
+
+  const wrap = document.createElement('div');
+  wrap.className = 'floating-bg';
+  wrap.setAttribute('aria-hidden', 'true');
+
+  const items = [];
+  for (let i = 0; i < count; i++) {
+    const slug = SLUGS[i % SLUGS.length];
+    const item = document.createElement('span');
+    item.className = 'floating-icon';
+
+    const depth = Math.random();
+    const size = Math.round(120 - depth * 70);
+    const blur = (depth * 3.5).toFixed(2);
+    const baseOpacity = (0.5 - depth * 0.35).toFixed(2);
+    const duration = 14 + depth * 20;
+    const delay = -Math.random() * duration;
+    const drift = (Math.random() * 40 - 20).toFixed(1);
+    const rotate = (Math.random() * 30 - 15).toFixed(1);
+
+    item.style.left = `${Math.random() * 100}%`;
+    item.style.top = `${Math.random() * 100}%`;
+    item.style.animationDuration = `${duration.toFixed(1)}s`;
+    item.style.animationDelay = `${delay.toFixed(1)}s`;
+    item.style.setProperty('--drift', `${drift}px`);
+    item.style.setProperty('--rotate', `${rotate}deg`);
+    item.style.setProperty('--blur', `${blur}px`);
+    item.style.setProperty('--base-opacity', baseOpacity);
+    item.style.zIndex = String(Math.round((1 - depth) * 10));
+
+    const img = createEmojiImg(slug);
+    img.width = size;
+    img.height = size;
+    item.appendChild(img);
+    wrap.appendChild(item);
+    items.push(item);
+  }
+
+  document.body.insertBefore(wrap, document.body.firstChild);
+
+  const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+  if (reduce) return;
+
+  const REPEL_RADIUS = 180;
+  const REPEL_MAX = 32;
+  let rafId = 0;
+  let mx = -9999;
+  let my = -9999;
+
+  const apply = () => {
+    rafId = 0;
+    for (const el of items) {
+      const r = el.getBoundingClientRect();
+      const cx = r.left + r.width / 2;
+      const cy = r.top + r.height / 2;
+      const dx = cx - mx;
+      const dy = cy - my;
+      const dist = Math.hypot(dx, dy);
+      if (dist < REPEL_RADIUS && dist > 0.1) {
+        const force = (1 - dist / REPEL_RADIUS) * REPEL_MAX;
+        el.style.setProperty('--repel-x', `${((dx / dist) * force).toFixed(1)}px`);
+        el.style.setProperty('--repel-y', `${((dy / dist) * force).toFixed(1)}px`);
+        el.style.setProperty('--repel-opacity', '0.55');
+      } else {
+        el.style.setProperty('--repel-x', '0px');
+        el.style.setProperty('--repel-y', '0px');
+        el.style.setProperty('--repel-opacity', '');
+      }
+    }
+  };
+
+  window.addEventListener('mousemove', (e) => {
+    mx = e.clientX;
+    my = e.clientY;
+    if (!rafId) rafId = requestAnimationFrame(apply);
+  });
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v35';
+const VERSION = 'couplecards-v36';
 const SHELL = [
   '/',
   '/index.html',
@@ -43,6 +43,7 @@ const SHELL = [
   '/js/features/admin/deck-sync.js',
   '/js/features/admin/emoji-slugs.js',
   '/js/ui/emoji.js',
+  '/js/ui/floating-bg.js',
   '/js/ui/shell.js',
   '/js/ui/password-strength.js',
   '/js/ui/scroll-to-top.js',


### PR DESCRIPTION
## Summary

Ports the depth-driven background from the sibling project meetingtime (its `FloatingBackground` component on the home page), retargeted to use the Fluent UI emoji SVGs we already ship under `/icons/emoji/`. A curated thematic slug list (hearts, kiss-mark, popping cork, cocktail, popcorn, guitar, hiking boot, game die, crystal ball, etc.) keeps the vibe consistent with the deck content instead of pulling random objects from the full 134-slug set.

A single per-icon `depth` value drives size, blur, opacity, animation duration and z-index together, so the layers read as actual distance. On desktop the cursor gently repels nearby icons (180 px radius, 32 px max offset). Both the loop and the listener are gated by `prefers-reduced-motion`.

The component mounts directly under `<body>` (out of any future SPA `#app` container) and z-indexes below `.auth-shell`. The auth card was already translucent with `backdrop-filter: blur(10px)`, which lets the parallax show through the card instead of fighting it.

## Scope

- Login page only. `index.html` (the SPA home) is unchanged.
- `public/js/ui/floating-bg.js` (new, ~95 lines).
- `public/css/auth.css` gains the floating background CSS and two `@keyframes`. `.auth-shell` becomes a positioned element to win the stacking battle.
- `public/js/login.js` calls `mountFloatingBackground()` at the start of `init()`.
- Service worker version bumped (v35 to v36) and the new module added to `SHELL`.

## Expected behaviours

- Open `/login.html`: about 22 thematic emojis float slowly behind the sign-in card, with size, blur and opacity layered to look like depth. The auth card stays fully readable.
- Move the mouse on desktop: icons within 180 px of the cursor drift smoothly out of the way and fade back in once the cursor leaves.
- Enable "reduce motion" at the OS level: no animation, no mousemove listener, icons stay still.
- After the language switch or any other re-render, the background stays mounted (it lives under `<body>`, not inside `.auth-shell`).
- Existing PWAs pick up the new asset on the next service worker activation.