### PR TITLE
chore(ignore): exclude the .claude/ tooling directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,4 @@ deploy/
 *.md
 !CREDITS.md
 !LICENSE
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 .idea/
 public/vendor/
 CLAUDE.md
+.claude/


### PR DESCRIPTION
## Summary

The bare `CLAUDE.md` pattern in `.gitignore` already matches at any depth (root + `data/` + `public/locales/`). Its sibling `.claude/` directory (Claude Code's per-project skills, settings and memory) was untracked but not ignored, so a `git add .` would have swept it in. Same gap in `.dockerignore`, where it could have leaked into the published image. Both files now list `.claude/` explicitly.

## Expected behaviours

- `git check-ignore -v .claude/` reports the new line in `.gitignore`.
- `docker build .` no longer copies `.claude/` into the build context.
- No existing tracked files change. The directory was already absent from history.