### PR TITLE
chore(release): cut version 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-05-27
+
 ### Added
 
 - The Collection screen gains a search field that filters discovered cards by title and description, plus a completion bar above the counter that fills with the active pile or rarity filter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/compress": "^8.3.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "type": "module",
   "description": "Couplecards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

Cut version 1.9.0. Bumps the version in the root and server `package.json` and `package-lock.json`, and promotes the `[Unreleased]` CHANGELOG section to `1.9.0` dated today.

## Included since 1.8.0

### Added

- Collection screen search field (filters discovered cards by title and description) and a deck-completion bar above the counter.

### Fixed

- French typography and grammar corrections in a few `fr.json` strings.
