### PR TITLE
docs: align README screenshot table separator widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The app works offline once loaded.
 A hosted demo is available at **<https://couplecards.qiaeru.com/>**. Sign in with `demo` / `demo`. The demo account's state is wiped on every sign-in, so feel free to click anything.
 
 | Home | Reveal |
-| :--: | :----: |
+| :--: | :--: |
 | ![Couplecards home screen with the two piles](./docs/assets/screenshot1.png) | ![A drawn Couplecards card](./docs/assets/screenshot2.png) |
 | *The two piles on the home screen* | *A card revealed from the deck* |
 


### PR DESCRIPTION
Markdown table consistency pass requested by the owner.

The project has three markdown tables. Two (`docs/architecture.md`, `docs/configuration.md`) already use the standard `| --- |` separator. The README screenshot table stays centered on purpose, but its two cells used different widths (`:--:` and `:----:`). This aligns both to the documented `:--:` style.

No rendered output changes: the table is still centered.
