### PR TITLE
fix: robustness pass (error handler, SW precache, session key, sync signals)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - API error responses now use the documented shape (`VALIDATION_ERROR`, error codes): the custom error handler was registered after the route scopes, so Fastify's default handler answered instead and leaked technical messages in the body. Client errors (4xx) are also logged as warnings now, keeping the `error` level for real server faults.
 - Offline support no longer breaks silently when a single asset fails to precache: the Service Worker caches each shell file individually instead of abandoning the whole batch, and logs what failed.
+- "Reset my data" no longer discards the cached deck version, which forced a needless full deck re-download on the next load.
 
 ## [1.9.0] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Offline support no longer breaks silently when a single asset fails to precache: the Service Worker caches each shell file individually instead of abandoning the whole batch, and logs what failed.
 - "Reset my data" no longer discards the cached deck version, which forced a needless full deck re-download on the next load.
 - A `SESSION_SECRET` containing multi-byte characters (accents, emoji) in its first 32 characters no longer crashes the server at startup: the session key is now truncated in bytes, not characters.
+- The client no longer announces a clean sync when the history upload fails: the entries stay queued and retry on the next online event, only the pending counter refreshes.
 
 ## [1.9.0] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - A `SESSION_SECRET` containing multi-byte characters (accents, emoji) in its first 32 characters no longer crashes the server at startup: the session key is now truncated in bytes, not characters.
 - The client no longer announces a clean sync when the history upload fails: the entries stay queued and retry on the next online event, only the pending counter refreshes.
 
+### Changed
+
+- The Collection search waits 150 ms after the last keystroke before re-rendering the grid, sparing low-end phones a full rebuild per typed letter.
+
 ## [1.9.0] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - API error responses now use the documented shape (`VALIDATION_ERROR`, error codes): the custom error handler was registered after the route scopes, so Fastify's default handler answered instead and leaked technical messages in the body. Client errors (4xx) are also logged as warnings now, keeping the `error` level for real server faults.
 - Offline support no longer breaks silently when a single asset fails to precache: the Service Worker caches each shell file individually instead of abandoning the whole batch, and logs what failed.
 - "Reset my data" no longer discards the cached deck version, which forced a needless full deck re-download on the next load.
+- A `SESSION_SECRET` containing multi-byte characters (accents, emoji) in its first 32 characters no longer crashes the server at startup: the session key is now truncated in bytes, not characters.
 
 ## [1.9.0] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - API error responses now use the documented shape (`VALIDATION_ERROR`, error codes): the custom error handler was registered after the route scopes, so Fastify's default handler answered instead and leaked technical messages in the body. Client errors (4xx) are also logged as warnings now, keeping the `error` level for real server faults.
+- Offline support no longer breaks silently when a single asset fails to precache: the Service Worker caches each shell file individually instead of abandoning the whole batch, and logs what failed.
 
 ## [1.9.0] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- API error responses now use the documented shape (`VALIDATION_ERROR`, error codes): the custom error handler was registered after the route scopes, so Fastify's default handler answered instead and leaked technical messages in the body. Client errors (4xx) are also logged as warnings now, keeping the `error` level for real server faults.
+
 ## [1.9.0] - 2026-05-27
 
 ### Added

--- a/public/js/core/idb.js
+++ b/public/js/core/idb.js
@@ -100,7 +100,11 @@ export const idb = {
     const db = await openDb();
     return new Promise((resolve, reject) => {
       const transaction = db.transaction(['state', 'outbox'], 'readwrite');
-      transaction.objectStore('state').clear();
+      // Keep `cardsVersion`: the deck cache is not user state, and wiping the
+      // version would force a full deck re-download on the next load.
+      const state = transaction.objectStore('state');
+      state.delete('banned');
+      state.delete('history');
       transaction.objectStore('outbox').clear();
       transaction.oncomplete = resolve;
       transaction.onerror = () => reject(transaction.error);

--- a/public/js/core/sync.js
+++ b/public/js/core/sync.js
@@ -308,8 +308,12 @@ async function flushOutbox() {
         for (const { item } of historyBatch) {
           await idb.removeOutbox(item.id);
         }
-      } catch (err) {
-        if (err?.status === 401) return;
+      } catch {
+        // The ban chains above may have drained, so refresh the pending badge,
+        // but don't announce a clean flush while history entries are still
+        // queued. The next online event retries them.
+        notifyOutboxChanged();
+        return;
       }
     }
     emit('sync:flushed');

--- a/public/js/features/collection/collection.js
+++ b/public/js/features/collection/collection.js
@@ -15,6 +15,7 @@ let currentFilter = 'all';
 let currentQuery = '';
 let lastSeenCount = null;
 let freshIds = new Set();
+let searchDebounce = 0;
 
 // A card is "discovered" once it has appeared at least once in the user's
 // history, regardless of whether that draw ended in a return or a ban.
@@ -236,7 +237,10 @@ export function mount() {
   currentQuery = '';
   document.getElementById('collection-search')?.addEventListener('input', (e) => {
     currentQuery = e.target.value;
-    render();
+    // Debounce: rebuilding the full grid on every keystroke is wasteful on
+    // low-end phones, and 150 ms is below the perception threshold.
+    clearTimeout(searchDebounce);
+    searchDebounce = setTimeout(render, 150);
   });
 
   // The most recently drawn card pulses so the user can spot it immediately
@@ -257,4 +261,6 @@ export function unmount() {
   unsubscribe.forEach((u) => u && u());
   unsubscribe = [];
   freshIds = new Set();
+  clearTimeout(searchDebounce);
+  searchDebounce = 0;
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v37';
+const VERSION = 'couplecards-v38';
 const SHELL = [
   '/',
   '/index.html',
@@ -84,7 +84,13 @@ const SHELL = [
 self.addEventListener('install', (event) => {
   event.waitUntil((async () => {
     const cache = await caches.open(VERSION);
-    await cache.addAll(SHELL).catch(() => {});
+    // Cache each asset individually: with addAll a single failing asset
+    // would silently abandon the whole shell and break offline support.
+    const results = await Promise.allSettled(SHELL.map((url) => cache.add(url)));
+    const failed = SHELL.filter((_, i) => results[i].status === 'rejected');
+    if (failed.length > 0) {
+      console.warn(`[sw] shell precache: ${failed.length}/${SHELL.length} assets failed:`, failed.join(', '));
+    }
   })());
 });
 

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -33,12 +33,14 @@ const SESSION_SECRET = NODE_ENV === 'production'
   ? required('SESSION_SECRET')
   : (process.env.SESSION_SECRET || 'dev-secret-change-me-0123456789abcdef0123456789abcdef');
 
-// @fastify/secure-session requires at least 32 bytes.
+// @fastify/secure-session requires an exactly 32-byte key. Truncate in bytes,
+// not characters: a multi-byte (accented) character inside the first 32
+// characters would otherwise yield an oversized buffer and crash the boot.
 function sessionKey(secret) {
   if (secret.length < 32) {
     throw new Error('SESSION_SECRET must be at least 32 characters');
   }
-  return Buffer.from(secret.slice(0, 32), 'utf8');
+  return Buffer.from(secret, 'utf8').subarray(0, 32);
 }
 
 const DATA_DIR = process.env.DATA_DIR || resolve(process.cwd(), 'var');

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -56,6 +56,25 @@ async function buildApp() {
   await app.register(sessionPlugin);
   await app.register(csrfPlugin);
 
+  // Must be set before the route plugins are registered: encapsulated scopes
+  // inherit the error handler that exists at their creation, so a handler set
+  // afterwards never applies to them and Fastify's default (which leaks the
+  // technical error message in the response body) takes over.
+  app.setErrorHandler((error, request, reply) => {
+    // Client errors (validation, CSRF, bad input) are expected traffic: log
+    // them as warnings so `error` stays reserved for actual server faults.
+    if (error.validation) {
+      request.log.warn({ err: error }, 'request failed');
+      return reply.code(400).send({ error: 'VALIDATION_ERROR', details: error.validation });
+    }
+    if (error.statusCode && error.statusCode < 500) {
+      request.log.warn({ err: error }, 'request failed');
+      return reply.code(error.statusCode).send({ error: error.code || 'REQUEST_FAILED' });
+    }
+    request.log.error({ err: error }, 'request failed');
+    return reply.code(500).send({ error: 'INTERNAL_ERROR' });
+  });
+
   // Mounted at root so <link rel="manifest"> resolves without the /api prefix.
   await app.register(manifestRoutes);
 
@@ -70,17 +89,6 @@ async function buildApp() {
     await scope.register(userRoutes);
     await scope.register(adminCardRoutes);
   }, { prefix: '/api/admin' });
-
-  app.setErrorHandler((error, _request, reply) => {
-    app.log.error({ err: error }, 'request failed');
-    if (error.validation) {
-      return reply.code(400).send({ error: 'VALIDATION_ERROR', details: error.validation });
-    }
-    if (error.statusCode && error.statusCode < 500) {
-      return reply.code(error.statusCode).send({ error: error.code || 'REQUEST_FAILED' });
-    }
-    return reply.code(500).send({ error: 'INTERNAL_ERROR' });
-  });
 
   await app.register(staticPlugin);
 


### PR DESCRIPTION
Robustness pass from a full project review. Six independent fixes, one commit each.

## Server

- **Error handler never applied to API routes.** `setErrorHandler` was registered after the route scopes, so Fastify's default handler answered with its own shape and leaked technical messages in the body. The handler now sits before route registration, responses match the documented `{ error: CODE }` shape (which `public/js/core/api.js` and `docs/security.md` already assumed), and 4xx errors are logged at `warn` so `error` stays reserved for server faults.
- **Session key truncated in bytes.** `secret.slice(0, 32)` produced an oversized key buffer when an accented character sat in the first 32 characters, crashing the boot. The UTF-8 byte encoding is truncated instead.

## Client

- **Service Worker precache is per-asset.** `cache.addAll` is all-or-nothing: one failing asset silently disabled offline support. Assets are cached individually and failures are logged. SW version bumped.
- **"Reset my data" keeps the deck cache version.** `clearState()` wiped `cardsVersion` along with the user state, forcing a full deck re-download on the next load. Only `banned` and `history` are deleted now.
- **No false "synced" signal.** `flushOutbox` emitted `sync:flushed` even when the history POST failed with a non-401 error. It now refreshes the pending badge and bails; entries retry on the next online event.
- **Collection search debounced (150 ms)** so each keystroke no longer rebuilds the full tile grid.

## Expected behaviours

- API validation errors return `{ "error": "VALIDATION_ERROR", "details": [...] }`; other 4xx return their error code; 5xx return `INTERNAL_ERROR`.
- The server boots with a `SESSION_SECRET` containing accents.
- A missing shell asset no longer disables offline mode for everything else.
- After a user data reset, `/api/cards` still answers 304 when the deck is unchanged.

Validated locally: server boot, demo login, cards/state/bans/history round-trips, validation and CSRF error shapes, warn-level 4xx logs.
