### PR TITLE
fix: review pass (lockout counter, manifest Vary, Docker builds)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,5 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.image }}:${{ github.ref_name }}
             ${{ steps.meta.outputs.image }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - "Reset my data" no longer discards the cached deck version, which forced a needless full deck re-download on the next load.
 - A `SESSION_SECRET` containing multi-byte characters (accents, emoji) in its first 32 characters no longer crashes the server at startup: the session key is now truncated in bytes, not characters.
 - The client no longer announces a clean sync when the history upload fails: the entries stay queued and retry on the next online event, only the pending counter refreshes.
+- Failed login attempts are now counted atomically in SQL: simultaneous wrong-password attempts could each read the same counter and under-count, delaying the account lockout.
+- The PWA manifest response now sends `Vary: Accept-Language`, so a shared cache (reverse proxy, CDN) can no longer serve one visitor's localized manifest to everyone.
+- The Settings screen no longer accumulates document-level install-prompt listeners across repeat visits.
 
 ### Changed
 
 - The Collection search waits 150 ms after the last keystroke before re-rendering the grid, sparing low-end phones a full rebuild per typed letter.
+- Docker images are now built with `npm ci` against the committed lockfiles, so every build of a given commit ships the exact dependency versions that were tested. The container healthcheck uses Node's built-in `fetch` instead of shipping `wget`.
 
 ## [1.9.0] - 2026-05-27
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,15 @@ ARG REVISION=unknown
 # ---- Stage 1: Backend deps ----
 FROM node:24-slim AS backend-deps
 WORKDIR /build
-COPY server/package.json ./
-RUN npm install --omit=dev --no-audit --no-fund
+COPY server/package.json server/package-lock.json ./
+RUN npm ci --omit=dev --no-audit --no-fund
 
 # ---- Stage 2: Browser vendor bundle (zxcvbn-ts) ----
 FROM node:24-slim AS vendor
 WORKDIR /build
-COPY package.json ./
+COPY package.json package-lock.json ./
 COPY scripts ./scripts
-RUN npm install --no-audit --no-fund
+RUN npm ci --no-audit --no-fund
 COPY public ./public
 RUN node scripts/build-vendor.mjs
 
@@ -35,7 +35,7 @@ LABEL org.opencontainers.image.title="couplecards" \
       org.opencontainers.image.revision="$REVISION"
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends tini wget \
+  && apt-get install -y --no-install-recommends tini \
   && rm -rf /var/lib/apt/lists/* \
   && groupadd --system --gid 999 app \
   && useradd --system --uid 999 --gid 999 --home-dir /app --shell /usr/sbin/nologin app
@@ -55,7 +55,7 @@ RUN mkdir -p /app/var && chown -R app:app /app
 USER app
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:3000/api/health >/dev/null 2>&1 || exit 1
+  CMD ["node", "-e", "fetch('http://127.0.0.1:3000/api/health').then((r) => process.exit(r.ok ? 0 : 1), () => process.exit(1))"]
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["node", "server/src/index.js"]

--- a/public/js/features/settings/settings.js
+++ b/public/js/features/settings/settings.js
@@ -9,6 +9,10 @@ import { setLocale, getLocale, supportedLocales, t } from '../../core/i18n.js';
 import { navigate } from '../../core/router.js';
 import { bindPasswordStrength } from '../../ui/password-strength.js';
 
+// Document-level listener, removed on unmount (view-local listeners die with
+// the view's DOM, but document survives navigation).
+let refreshInstall = null;
+
 export async function mount() {
   document.getElementById('btn-back-home')?.addEventListener('click', () => navigate('home'));
 
@@ -51,7 +55,7 @@ export async function mount() {
   // Install row — visibility driven by the PWA install prompt.
   const installRow = document.getElementById('install-row');
   const installBtn = document.getElementById('install-btn');
-  const refreshInstall = () => { if (installRow) installRow.hidden = !canInstall(); };
+  refreshInstall = () => { if (installRow) installRow.hidden = !canInstall(); };
   refreshInstall();
   document.addEventListener('pwa-install-available', refreshInstall);
   document.addEventListener('pwa-installed', refreshInstall);
@@ -111,7 +115,13 @@ export async function mount() {
   }
 }
 
-export function unmount() {}
+export function unmount() {
+  if (refreshInstall) {
+    document.removeEventListener('pwa-install-available', refreshInstall);
+    document.removeEventListener('pwa-installed', refreshInstall);
+    refreshInstall = null;
+  }
+}
 
 async function openChangePasswordDialog() {
   const user = getCachedUser() || await me();

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards — stale-while-revalidate (allows offline viewing)
 //   * all other /api/* — network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v38';
+const VERSION = 'couplecards-v39';
 const SHELL = [
   '/',
   '/index.html',

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -90,19 +90,17 @@ export default async function authRoutes(app) {
 
     const ok = await verifyPassword(row.password_hash, password);
     if (!ok) {
-      const attempts = row.failed_attempts + 1;
-      if (attempts >= LOCKOUT_THRESHOLD) {
-        const until = new Date(Date.now() + LOCKOUT_MINUTES * 60_000)
-          .toISOString().replace('T', ' ').slice(0, 19);
-        db.prepare(`
-          UPDATE users SET failed_attempts = ?, locked_until = ?, updated_at = datetime('now')
-          WHERE id = ?
-        `).run(attempts, until, row.id);
-      } else {
-        db.prepare(`
-          UPDATE users SET failed_attempts = ?, updated_at = datetime('now') WHERE id = ?
-        `).run(attempts, row.id);
-      }
+      // Increment in SQL, not from the row read before the (slow) password
+      // verification: concurrent failures would otherwise overwrite each
+      // other's count and delay the lockout.
+      const until = new Date(Date.now() + LOCKOUT_MINUTES * 60_000)
+        .toISOString().replace('T', ' ').slice(0, 19);
+      db.prepare(`
+        UPDATE users SET failed_attempts = failed_attempts + 1,
+          locked_until = CASE WHEN failed_attempts + 1 >= ? THEN ? ELSE locked_until END,
+          updated_at = datetime('now')
+        WHERE id = ?
+      `).run(LOCKOUT_THRESHOLD, until, row.id);
       return reply.code(401).send({ error: 'INVALID_CREDENTIALS' });
     }
 

--- a/server/src/routes/manifest.js
+++ b/server/src/routes/manifest.js
@@ -39,6 +39,9 @@ export default async function manifestRoutes(app) {
     const locale = pickLocale(request.headers['accept-language']);
     reply.type('application/manifest+json');
     reply.header('Cache-Control', 'public, max-age=3600');
+    // The body depends on Accept-Language; without Vary a shared cache could
+    // serve one locale's manifest to every visitor.
+    reply.header('Vary', 'Accept-Language');
     return manifests.get(locale) ?? manifests.get(FALLBACK_LOCALE);
   });
 }


### PR DESCRIPTION
## Summary

Hardening pass over the server, the PWA layer and the build, following a full code review. Four small fixes and two build improvements, all independent.

## Scope

- `server/src/routes/auth.js`: the failed-login counter was read before the (slow) password verification and written back afterwards, so concurrent wrong-password attempts could overwrite each other's count and delay the account lockout. The increment and the lockout threshold check now happen atomically in a single SQL statement.
- `server/src/routes/manifest.js`: the manifest body depends on `Accept-Language` but was served with `Cache-Control: public` and no `Vary` header, letting a shared cache (reverse proxy, CDN) serve one locale's manifest to every visitor. Adds `Vary: Accept-Language`.
- `public/js/features/settings/settings.js`: the two document-level PWA install listeners were re-added on every visit to the Settings screen and never removed. They are now cleaned up on unmount (Service Worker version bumped accordingly).
- `Dockerfile`: both npm stages now copy the committed `package-lock.json` and run `npm ci` instead of `npm install`, making image builds reproducible. The healthcheck uses Node's built-in `fetch`, removing the `wget` package from the runtime image.
- `.github/workflows/release.yml`: enables the GitHub Actions buildx layer cache, speeding up multi-arch release builds.

## Expected behaviours

- Ten wrong passwords lock the account for 15 minutes even when attempts arrive simultaneously; a successful login still resets the counter and the lock.
- Behind a caching proxy, a French browser and a German browser each receive their own manifest.
- Visiting Settings repeatedly adds no duplicate listeners.
- Two Docker builds of the same commit produce identical dependency trees; `docker inspect` healthchecks keep reporting healthy.

Verified locally: failed-attempt increments, lockout trigger at the threshold, reset on success, and the `Vary` header were all exercised against a running dev server.
