### PR TITLE
docs(cards): prose pass and US English across all five locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- Documentation and code comments now use US spelling and punctuation consistently.
+- Standardized on US spelling and punctuation across the documentation, the code comments, and the card deck, and gave the card titles and descriptions a prose polish in all five languages.
 
 ### Fixed
 

--- a/data/cards.de.json
+++ b/data/cards.de.json
@@ -353,7 +353,7 @@
       "foil": true,
       "emoji": "speech-balloon",
       "title": "Verbotene Worte",
-      "description": "Dirty Talk ohne Hemmungen während des Akts. Kein Wort tabu, sag alles, was dir kommt."
+      "description": "Dirty Talk ohne Hemmungen während des Akts. Nichts ist tabu, sag alles, was dir kommt."
     },
     {
       "id": "home-051",
@@ -387,7 +387,7 @@
       "id": "home-055",
       "pile": "home",
       "emoji": "coin",
-      "title": "Verbotene Wetten",
+      "title": "Kopf, du verlierst",
       "description": "Wir setzen unvernünftige Pfänder auf Kopf oder Zahl. Der Verlierer steht bis zum Ende."
     },
     {
@@ -409,7 +409,7 @@
       "pile": "home",
       "emoji": "performing-arts",
       "title": "Sonntags-Shakespeare",
-      "description": "Spiel eine unmögliche Szene mit Ernst. Wer zuerst rausfällt, verliert die Ehre."
+      "description": "Spiel eine unmögliche Szene mit unbewegter Miene. Wer zuerst rausfällt, verliert die Ehre."
     },
     {
       "id": "home-059",
@@ -451,7 +451,7 @@
       "pile": "home",
       "emoji": "crystal-ball",
       "title": "Astrologie-Pleite",
-      "description": "Tageshoroskop mit Ernst vorlesen. Wir reißen jede Vorhersage gnadenlos auseinander."
+      "description": "Tageshoroskop andächtig vorlesen. Wir reißen jede Vorhersage gnadenlos auseinander."
     },
     {
       "id": "home-065",
@@ -486,7 +486,7 @@
       "pile": "home",
       "emoji": "writing-hand",
       "title": "Roman in Tag-Team",
-      "description": "Eine Geschichte Satz für Satz im Wechsel. Je verdrehter, desto besser."
+      "description": "Eine Geschichte Satz für Satz im Wechsel. Bonus für jede absurde Wendung."
     },
     {
       "id": "home-070",
@@ -916,7 +916,7 @@
       "pile": "outdoor",
       "emoji": "thinking-face",
       "title": "Erfundene Leben",
-      "description": "Erfinden wir die schamhaftesten Geheimnisse der Fremden. Je trashiger, desto besser."
+      "description": "Erfinden wir die schamhaftesten Geheimnisse der Fremden. Das Schmutzigste gewinnt."
     },
     {
       "id": "out-061",
@@ -950,7 +950,7 @@
       "id": "out-065",
       "pile": "outdoor",
       "emoji": "shortcake",
-      "title": "Patisserie-Demolition",
+      "title": "Tortenschlacht",
       "description": "Eine komplizierte Torte mit dem Teelöffel zerlegen. Der Konditor wäre beleidigt."
     },
     {
@@ -964,7 +964,7 @@
       "id": "out-067",
       "pile": "outdoor",
       "emoji": "t-shirt",
-      "title": "Schäm-Secondhand",
+      "title": "Grausames Makeover",
       "description": "Wir wählen das absurdeste Outfit für den anderen. Foto in der Kabine Pflicht."
     },
     {
@@ -1021,7 +1021,7 @@
       "pile": "outdoor",
       "emoji": "selfie",
       "title": "Influencer für einen Tag",
-      "description": "Lächerliche Posen in der Stadt für zehn Story-Fotos. Ernst und Unschärfe Pflicht."
+      "description": "Lächerliche Posen in der Stadt für zehn Story-Fotos. Versteinerte Miene und Unschärfe Pflicht."
     }
   ]
 }

--- a/data/cards.en.json
+++ b/data/cards.en.json
@@ -13,7 +13,7 @@
       "pile": "home",
       "emoji": "game-die",
       "title": "Games in bad faith",
-      "description": "Board-game duel where cheating is a duty. Loser owes an unreasonable favour."
+      "description": "Board-game duel where cheating is a duty. Loser owes an unreasonable favor."
     },
     {
       "id": "home-003",
@@ -28,7 +28,7 @@
       "foil": true,
       "emoji": "clapper-board",
       "title": "Carnal cinematography",
-      "description": "An erotic film for \"the plot\". How many minutes before we abandon the screen?"
+      "description": "An erotic film for \"the plot.\" How many minutes before we abandon the screen?"
     },
     {
       "id": "home-005",
@@ -78,7 +78,7 @@
       "foil": true,
       "emoji": "camera",
       "title": "Compromising evidence",
-      "description": "Improvised photo shoot. Starts as portraits, ends as compromising material."
+      "description": "Improvised photo shoot. Starts as portraits, ends as pure blackmail material."
     },
     {
       "id": "home-012",
@@ -92,7 +92,7 @@
       "pile": "home",
       "emoji": "headphone",
       "title": "Punitive music quiz",
-      "description": "Name the artist or accept the forfeit. Your lack of music culture is about to cost you."
+      "description": "Name the artist or accept the forfeit. Your lack of musical knowledge is about to cost you."
     },
     {
       "id": "home-014",
@@ -100,7 +100,7 @@
       "foil": true,
       "emoji": "game-die",
       "title": "Textile probabilities",
-      "description": "The dice decide your striptease. Maths has never been this exciting."
+      "description": "The dice decide your striptease. Math has never been this exciting."
     },
     {
       "id": "home-015",
@@ -193,7 +193,7 @@
       "pile": "home",
       "emoji": "puzzle-piece",
       "title": "Puzzle negotiation",
-      "description": "Patience and focus. The last piece is bartered for a non-negotiable favour."
+      "description": "Patience and focus. The last piece is bartered for a non-negotiable favor."
     },
     {
       "id": "home-030",
@@ -232,7 +232,7 @@
       "foil": true,
       "emoji": "strawberry",
       "title": "Flesh buffet",
-      "description": "Sensual tasting, directly on the skin. Savour hands-free, with appetite."
+      "description": "Sensual tasting, directly on the skin. Savor hands-free, with appetite."
     },
     {
       "id": "home-035",
@@ -353,7 +353,7 @@
       "foil": true,
       "emoji": "speech-balloon",
       "title": "Forbidden words",
-      "description": "Full dirty talk during the act. No taboo words, say whatever crosses your mind."
+      "description": "Full dirty talk during the act. Nothing off-limits, say whatever crosses your mind."
     },
     {
       "id": "home-051",
@@ -367,7 +367,7 @@
       "pile": "home",
       "emoji": "balance-scale",
       "title": "Final judgement",
-      "description": "Dubious purity test found online. An occasion to mock your past with humour."
+      "description": "Dubious purity test found online. A chance to mock your past with humor."
     },
     {
       "id": "home-053",
@@ -387,7 +387,7 @@
       "id": "home-055",
       "pile": "home",
       "emoji": "coin",
-      "title": "Forbidden bids",
+      "title": "Heads you lose",
       "description": "Wager unreasonable forfeits on a coin flip. Loser sees it through to the end."
     },
     {
@@ -402,14 +402,14 @@
       "pile": "home",
       "emoji": "thumbs-up",
       "title": "Thumb war",
-      "description": "Brutal and effective. Loser clears the table or offers an immediate favour."
+      "description": "Brutal and effective. Loser clears the table or offers an immediate favor."
     },
     {
       "id": "home-058",
       "pile": "home",
       "emoji": "performing-arts",
       "title": "Sunday Shakespeare",
-      "description": "Act out an improbable scene with full seriousness. First to break has lost their honour."
+      "description": "Act out an improbable scene, deadpan. First to break has lost their honour."
     },
     {
       "id": "home-059",
@@ -437,7 +437,7 @@
       "pile": "home",
       "emoji": "microphone",
       "title": "Living-room karaoke",
-      "description": "Improvised mic, YouTube on. The most off-key pays for tomorrow's coffee."
+      "description": "Improvised mic, YouTube on. The most off-key buys a round of water."
     },
     {
       "id": "home-063",
@@ -451,7 +451,7 @@
       "pile": "home",
       "emoji": "crystal-ball",
       "title": "Botched astrology",
-      "description": "Read today's horoscope with full seriousness. Demolish every prediction without mercy."
+      "description": "Read today's horoscope, po-faced. Tear every prediction apart without mercy."
     },
     {
       "id": "home-065",
@@ -486,7 +486,7 @@
       "pile": "home",
       "emoji": "writing-hand",
       "title": "Tag-team novel",
-      "description": "A story written one sentence at a time. The weirder, the better."
+      "description": "A story written one sentence at a time. Bonus points for every absurd plot twist."
     },
     {
       "id": "home-070",
@@ -571,7 +571,7 @@
       "pile": "outdoor",
       "emoji": "paintbrush",
       "title": "Urban snobbery",
-      "description": "Graffiti hunt. Analyse scribbles as if they were high art."
+      "description": "Graffiti hunt. Analyze scribbles as if they were high art."
     },
     {
       "id": "out-012",
@@ -676,7 +676,7 @@
       "pile": "outdoor",
       "emoji": "beer-mug",
       "title": "Local brews",
-      "description": "Try the neighbourhood's beers. Leave with a pack and a sharply-held opinion."
+      "description": "Try the neighborhood's beers. Leave with a pack and a sharply-held opinion."
     },
     {
       "id": "out-027",
@@ -902,21 +902,21 @@
       "pile": "outdoor",
       "emoji": "bullseye",
       "title": "Darts and whisky",
-      "description": "Aim for the centre, hit the wall. Lowest score pays the round."
+      "description": "Aim for the center, hit the wall. Lowest score pays the round."
     },
     {
       "id": "out-059",
       "pile": "outdoor",
       "emoji": "money-bag",
       "title": "Millionaire dreams",
-      "description": "Judge prices at the estate agency. Laugh at our poverty with elegance."
+      "description": "Judge prices at the real estate office. Laugh at our poverty with elegance."
     },
     {
       "id": "out-060",
       "pile": "outdoor",
       "emoji": "thinking-face",
       "title": "Invented lives",
-      "description": "Imagine strangers' shameful secrets. The trashier, the better."
+      "description": "Imagine strangers' shameful secrets. The sleaziest one wins."
     },
     {
       "id": "out-061",
@@ -930,7 +930,7 @@
       "pile": "outdoor",
       "emoji": "fork-and-knife-with-plate",
       "title": "Gastronomic table",
-      "description": "Bring out the big guns and the snob vocabulary. Savour before draining the savings."
+      "description": "Bring out the big guns and the snob vocabulary. Savor before draining the savings."
     },
     {
       "id": "out-063",
@@ -950,8 +950,8 @@
       "id": "out-065",
       "pile": "outdoor",
       "emoji": "shortcake",
-      "title": "Pastry demolition",
-      "description": "Demolish a fancy cake with a teaspoon. The pastry chef would be offended."
+      "title": "Cake carnage",
+      "description": "Wreck a fancy cake with a teaspoon. The pastry chef would be offended."
     },
     {
       "id": "out-066",
@@ -964,7 +964,7 @@
       "id": "out-067",
       "pile": "outdoor",
       "emoji": "t-shirt",
-      "title": "Thrift shop of shame",
+      "title": "Cruel makeover",
       "description": "Each picks the most ridiculous outfit for the other. Photo in the fitting room mandatory."
     },
     {
@@ -1021,7 +1021,7 @@
       "pile": "outdoor",
       "emoji": "selfie",
       "title": "Influencer for a day",
-      "description": "10 ridiculous story-style poses around town. Full seriousness, artistic blur required."
+      "description": "10 ridiculous story-style poses around town. Stone-faced, artistic blur required."
     }
   ]
 }

--- a/data/cards.es.json
+++ b/data/cards.es.json
@@ -353,7 +353,7 @@
       "foil": true,
       "emoji": "speech-balloon",
       "title": "Palabras prohibidas",
-      "description": "Dirty talk sin filtros durante el acto. Ninguna palabra tabú, di lo que te venga."
+      "description": "Dirty talk sin filtros durante el acto. Nada es tabú, di lo que te venga."
     },
     {
       "id": "home-051",
@@ -387,7 +387,7 @@
       "id": "home-055",
       "pile": "home",
       "emoji": "coin",
-      "title": "Apuestas prohibidas",
+      "title": "Cara, pierdes",
       "description": "Apostamos prendas irrazonables a cara o cruz. El perdedor lo asume hasta el final."
     },
     {
@@ -409,7 +409,7 @@
       "pile": "home",
       "emoji": "performing-arts",
       "title": "Molière dominical",
-      "description": "Interpreta una escena inverosímil con seriedad. El primero que ceda pierde el honor."
+      "description": "Interpreta una escena inverosímil sin pestañear. El primero que ceda pierde el honor."
     },
     {
       "id": "home-059",
@@ -451,7 +451,7 @@
       "pile": "home",
       "emoji": "crystal-ball",
       "title": "Astrología cutre",
-      "description": "Lectura seria del horóscopo del día. Demolemos cada predicción sin piedad."
+      "description": "Lectura solemne del horóscopo del día. Destrozamos cada predicción sin piedad."
     },
     {
       "id": "home-065",
@@ -486,7 +486,7 @@
       "pile": "home",
       "emoji": "writing-hand",
       "title": "Novela a relevos",
-      "description": "Una historia escrita por frases alternas. Cuanto más retorcida, mejor."
+      "description": "Una historia escrita por frases alternas. Bonus por cada giro absurdo."
     },
     {
       "id": "home-070",
@@ -916,7 +916,7 @@
       "pile": "outdoor",
       "emoji": "thinking-face",
       "title": "Vidas inventadas",
-      "description": "Imaginemos los secretos vergonzosos de los desconocidos. Cuanto más trash, mejor."
+      "description": "Imaginemos los secretos vergonzosos de los desconocidos. Gana el más sórdido."
     },
     {
       "id": "out-061",
@@ -950,8 +950,8 @@
       "id": "out-065",
       "pile": "outdoor",
       "emoji": "shortcake",
-      "title": "Demolición pastelera",
-      "description": "Demoler una tarta compleja con cucharilla. El pastelero se sentiría ofendido."
+      "title": "Carnicería pastelera",
+      "description": "Destrozar una tarta compleja con cucharilla. El pastelero se sentiría ofendido."
     },
     {
       "id": "out-066",
@@ -964,7 +964,7 @@
       "id": "out-067",
       "pile": "outdoor",
       "emoji": "t-shirt",
-      "title": "Mercadillo vergonzoso",
+      "title": "Cambio de look cruel",
       "description": "Elegimos para el otro el outfit más ridículo. Foto en el probador obligatoria."
     },
     {
@@ -1021,7 +1021,7 @@
       "pile": "outdoor",
       "emoji": "selfie",
       "title": "Influencer por un día",
-      "description": "Poses ridículas por la ciudad para 10 fotos tipo story. Seriedad y desenfoque artístico."
+      "description": "Poses ridículas por la ciudad para 10 fotos tipo story. Cara de palo y desenfoque artístico."
     }
   ]
 }

--- a/data/cards.fr.json
+++ b/data/cards.fr.json
@@ -353,7 +353,7 @@
       "foil": true,
       "emoji": "speech-balloon",
       "title": "Mots interdits",
-      "description": "Dirty talk assumé pendant l'acte. Aucun mot interdit, dis tout ce qui te passe."
+      "description": "Dirty talk assumé pendant l'acte. Aucun filtre, dis tout ce qui te passe par la tête."
     },
     {
       "id": "home-051",
@@ -387,7 +387,7 @@
       "id": "home-055",
       "pile": "home",
       "emoji": "coin",
-      "title": "Enchères interdites",
+      "title": "Pile, tu perds",
       "description": "On parie des gages déraisonnables sur un pile ou face. Le perdant assume jusqu'au bout."
     },
     {
@@ -409,7 +409,7 @@
       "pile": "home",
       "emoji": "performing-arts",
       "title": "Molière du dimanche",
-      "description": "Joue une scène improbable avec sérieux. Le premier qui décroche a perdu son honneur."
+      "description": "Joue une scène improbable, imperturbable. Le premier qui décroche a perdu son honneur."
     },
     {
       "id": "home-059",
@@ -451,7 +451,7 @@
       "pile": "home",
       "emoji": "crystal-ball",
       "title": "Astrologie foireuse",
-      "description": "Lecture de l'horoscope du jour, avec sérieux. On démolit chaque prédiction sans pitié."
+      "description": "Lecture de l'horoscope du jour, le visage grave. On descend chaque prédiction sans pitié."
     },
     {
       "id": "home-065",
@@ -486,7 +486,7 @@
       "pile": "home",
       "emoji": "writing-hand",
       "title": "Roman à quatre mains",
-      "description": "Une histoire écrite à tour de phrases. Plus c'est tordu, mieux c'est."
+      "description": "Une histoire écrite à tour de phrases. Bonus pour chaque rebondissement absurde."
     },
     {
       "id": "home-070",
@@ -916,7 +916,7 @@
       "pile": "outdoor",
       "emoji": "thinking-face",
       "title": "Vies inventées",
-      "description": "Imaginons les secrets honteux des inconnus. Plus c'est trash, mieux c'est."
+      "description": "Imaginons les secrets honteux des inconnus. Le plus glauque l'emporte."
     },
     {
       "id": "out-061",
@@ -951,7 +951,7 @@
       "pile": "outdoor",
       "emoji": "shortcake",
       "title": "Défi haute pâtisserie",
-      "description": "Démolir un gâteau complexe à la petite cuillère. Le pâtissier serait insulté."
+      "description": "Saccager un gâteau complexe à la petite cuillère. Le pâtissier serait insulté."
     },
     {
       "id": "out-066",
@@ -964,7 +964,7 @@
       "id": "out-067",
       "pile": "outdoor",
       "emoji": "t-shirt",
-      "title": "Friperie de la honte",
+      "title": "Relooking cruel",
       "description": "On choisit la tenue la plus ridicule pour l'autre. Photo obligatoire en cabine."
     },
     {
@@ -1021,7 +1021,7 @@
       "pile": "outdoor",
       "emoji": "selfie",
       "title": "Influenceur d'un jour",
-      "description": "Poses ridicules en ville pour 10 photos style story. Sérieux et flou artistique exigés."
+      "description": "Poses ridicules en ville pour 10 photos style story. Air pénétré et flou artistique exigés."
     }
   ]
 }

--- a/data/cards.it.json
+++ b/data/cards.it.json
@@ -353,7 +353,7 @@
       "foil": true,
       "emoji": "speech-balloon",
       "title": "Parole vietate",
-      "description": "Dirty talk senza freni durante l'atto. Nessuna parola tabù, di' tutto quello che ti viene."
+      "description": "Dirty talk senza freni durante l'atto. Niente è tabù, di' tutto quello che ti viene."
     },
     {
       "id": "home-051",
@@ -387,7 +387,7 @@
       "id": "home-055",
       "pile": "home",
       "emoji": "coin",
-      "title": "Aste vietate",
+      "title": "Testa, perdi",
       "description": "Scommettiamo penitenze irragionevoli su testa o croce. Il perdente porta avanti fino in fondo."
     },
     {
@@ -409,7 +409,7 @@
       "pile": "home",
       "emoji": "performing-arts",
       "title": "Molière domenicale",
-      "description": "Recita una scena improbabile con serietà. Chi cede per primo perde l'onore."
+      "description": "Recita una scena improbabile senza batter ciglio. Chi cede per primo perde l'onore."
     },
     {
       "id": "home-059",
@@ -451,7 +451,7 @@
       "pile": "home",
       "emoji": "crystal-ball",
       "title": "Astrologia fasulla",
-      "description": "Lettura seria dell'oroscopo del giorno. Demoliamo ogni previsione senza pietà."
+      "description": "Lettura solenne dell'oroscopo del giorno. Smontiamo ogni previsione senza pietà."
     },
     {
       "id": "home-065",
@@ -486,7 +486,7 @@
       "pile": "home",
       "emoji": "writing-hand",
       "title": "Romanzo a staffetta",
-      "description": "Una storia scritta a frasi alterne. Più è contorta, meglio è."
+      "description": "Una storia scritta a frasi alterne. Bonus per ogni svolta assurda."
     },
     {
       "id": "home-070",
@@ -916,7 +916,7 @@
       "pile": "outdoor",
       "emoji": "thinking-face",
       "title": "Vite inventate",
-      "description": "Immaginiamo i segreti vergognosi degli sconosciuti. Più è trash, meglio è."
+      "description": "Immaginiamo i segreti vergognosi degli sconosciuti. Vince il più sordido."
     },
     {
       "id": "out-061",
@@ -951,7 +951,7 @@
       "pile": "outdoor",
       "emoji": "shortcake",
       "title": "Sfida da pasticceria",
-      "description": "Demolire una torta complessa con il cucchiaino. Il pasticcere sarebbe offeso."
+      "description": "Devastare una torta complessa con il cucchiaino. Il pasticcere sarebbe offeso."
     },
     {
       "id": "out-066",
@@ -964,7 +964,7 @@
       "id": "out-067",
       "pile": "outdoor",
       "emoji": "t-shirt",
-      "title": "Vintage della vergogna",
+      "title": "Restyling crudele",
       "description": "Scegliamo per l'altro l'outfit più ridicolo. Foto in camerino obbligatoria."
     },
     {
@@ -1021,7 +1021,7 @@
       "pile": "outdoor",
       "emoji": "selfie",
       "title": "Influencer per un giorno",
-      "description": "Pose ridicole in città per dieci foto in stile story. Serietà e sfocatura artistica."
+      "description": "Pose ridicole in città per dieci foto in stile story. Faccia di marmo e sfocatura artistica."
     }
   ]
 }

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -12,6 +12,8 @@ The fallback language is English. When a key is missing from the user's locale, 
 
 French is the source of truth for new copy: every other locale is a **naturalization** of the French original, never a literal translation. Swap idioms, change cultural references, and restructure sentences so the result reads as if it were originally written in the target language. Word counts will diverge across locales and that is expected.
 
+The English locale uses US English: US spelling (favor, neighborhood, analyze), the serial comma, and commas and periods inside the quotation marks. This matches the US spelling and punctuation already used across the documentation and code comments. Both the UI strings and the card deck follow it.
+
 ## UI strings
 
 User-visible text lives in flat JSON files with dotted keys such as `login.title` or `admin.users.create.submit`, one file per locale under [`public/locales/`](../public/locales/) (`fr.json`, `en.json`, `de.json`, `it.json`, `es.json`). Every file shares the same key set in the same canonical section order (app/common, navigation, authentication, piles, draw, history, collection, settings, rules, demo, admin, errors). When you add a new key, slot it into its section rather than appending at the bottom.


### PR DESCRIPTION
## Summary

Prose pass over the card deck, the last part of the project that had not been through one, plus a switch of the English deck to US English for project-wide consistency.

## Scope

- **fr / en**: fixed two calques (musical knowledge, a chance to), removed within-card word echoes, and thinned the most repeated phrasings (mock-seriousness, "demolish", "the X-er, the better", a duplicated forfeit, and the "of shame" / "forbidden" title formulas).
- **en**: converted British spellings to US (favor, neighborhood, analyze, center, math) and moved punctuation inside the quotation marks.
- **de / it / es**: propagated the same card revisions so all five locales stay in sync.
- **docs**: recorded the US-English convention in `docs/i18n.md`.

## Expected behavior after merge

- All five `data/cards.*.json` keep identical structural fields (id, pile, foil, emoji), so the boot-time seed parity check passes.
- A fresh install seeds the new wording; an existing instance shows it after an admin "Sync from the files".
- No schema, route, or behavior change; the deck stays at 142 cards.
