### PR TITLE
fix(draw): repair desktop tilt freeze and foil card visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- On desktop, a drawn card no longer freezes after the cursor leaves and returns: the hover tilt keeps following the pointer instead of locking up.
+- Rare (foil) cards look cleaner: the golden halo now hugs the card instead of floating with a gap around it, and the holographic rainbow loops continuously instead of flashing a flat patch and snapping back each cycle.
 - Harmonized a few UI strings: consistent search placeholders, the admin card form now says "Tas" like the rest of the French UI, the weak-password error reuses the strength meter's wording, and an ambiguous French rules sentence ("la retirer") now clearly means the card can come back later.
 
 ## [1.10.0] - 2026-06-12

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -267,24 +267,28 @@
 .card-front.is-foil.for-home,
 .card-front.is-foil.for-outdoor {
   background:
-    /* Horizontal holographic reflection (scrolls left to right only) */
+    /* Horizontal holographic band (scrolls left to right only). The first
+       and last stops share the same color and the band is tiled (the
+       background shorthand resets background-repeat to repeat), so scrolling
+       it by exactly one image width loops seamlessly: the rainbow flows
+       continuously instead of snapping or flashing a flat patch each cycle. */
     linear-gradient(
-      100deg,
+      90deg,
       rgba(255, 120, 150, 0.40) 0%,
       rgba(255, 200, 120, 0.40) 20%,
       rgba(140, 240, 180, 0.40) 40%,
       rgba(120, 200, 255, 0.40) 60%,
       rgba(200, 140, 255, 0.40) 80%,
-      rgba(244, 156, 197, 0.40) 100%
+      rgba(255, 120, 150, 0.40) 100%
     ),
     /* Dark base so the iridescent tones stand out */
     linear-gradient(160deg, #2a1a4a 0%, #12082c 60%, #1a0f3a 100%);
-  background-size: 250% 100%, 100% 100%;
+  background-size: 200% 100%, 100% 100%;
   animation: foil-bg-shift 10s linear infinite;
 }
 @keyframes foil-bg-shift {
   0%   { background-position: 0% 0%, 0 0; }
-  100% { background-position: 250% 0%, 0 0; }
+  100% { background-position: 200% 0%, 0 0; }
 }
 
 /* Holographic heart pattern confined to the illustration panel. The 2px
@@ -405,13 +409,15 @@
 /* Golden halo pulsing around the foil card. Placed on .card-flip (which has
    no overflow:hidden) rather than on .card-front, whose .card-face wrapper
    clips it to invisibility. Uses ::before so the pile-specific ::after glow
-   on .card-flip can co-exist. */
+   on .card-flip can co-exist. The box is aligned to the card edge (inset 0,
+   matching the .card-face radius) so the glow starts right at the card and
+   spreads outward; a negative inset left a dark gap between card and halo. */
 .card-flip:has(.card-front.is-foil)::before {
   content: "";
   position: absolute;
-  inset: -16px;
-  border-radius: 24px;
-  box-shadow: 0 0 40px 4px rgba(255, 210, 140, 0.25);
+  inset: 0;
+  border-radius: 22px;
+  box-shadow: 0 0 40px 6px rgba(255, 210, 140, 0.30);
   pointer-events: none;
   z-index: -1;
   animation: foil-halo-pulse 3s ease-in-out infinite;

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -217,6 +217,7 @@ function smoothReturnToCenter() {
   const banLabel = tilt.querySelector('.swipe-label-ban');
   const returnLabel = tilt.querySelector('.swipe-label-return');
   if (returnRaf) cancelAnimationFrame(returnRaf);
+  returnRaf = 0;
   const parse = (name) => parseFloat(tilt.style.getPropertyValue(name) || '0');
   const rx0 = parse('--rx');
   const ry0 = parse('--ry');
@@ -232,6 +233,7 @@ function smoothReturnToCenter() {
     tilt.style.setProperty('--tz', '0deg');
     if (banLabel) banLabel.style.opacity = 0;
     if (returnLabel) returnLabel.style.opacity = 0;
+    isReturning = false;
     return;
   }
   isReturning = true;
@@ -328,15 +330,23 @@ function attachTilt() {
   };
 
   tiltPointerMove = (e) => {
-    if (isReturning) return;
     const isMouse = e.pointerType === 'mouse';
     if (isMouse && !pointerDown) {
+      // Desktop hover: the cursor is back over the card, so cancel any
+      // in-flight smooth-return and let the pointer drive the tilt again.
+      // Otherwise a return started on pointerleave keeps the isReturning
+      // guard raised and the follow effect stays frozen.
+      if (isReturning) {
+        if (returnRaf) { cancelAnimationFrame(returnRaf); returnRaf = 0; }
+        isReturning = false;
+      }
       pendingX = e.clientX;
       pendingY = e.clientY;
       if (raf) return;
       raf = requestAnimationFrame(() => { raf = 0; updateTiltFromPointer(); });
       return;
     }
+    if (isReturning) return;
     if (!pointerDown) return;
     const dx = e.clientX - startX;
     const dy = e.clientY - startY;

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards: stale-while-revalidate (allows offline viewing)
 //   * all other /api/*: network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v41';
+const VERSION = 'couplecards-v42';
 const SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

Three fixes to the draw screen's card rendering and hover interaction, plus a Service Worker cache bump.

## Scope

- `draw.js` (tilt): the desktop hover tilt could get permanently stuck. `smoothReturnToCenter()` returned early when the card was already near center without clearing the `isReturning` guard, after which every `pointermove` was ignored. The early branch now clears the flag, and a mouse hover cancels an in-flight return so the pointer takes over immediately.
- `cards.css` (foil halo): the pulsing golden halo sat on a box inset by `-16px`, so its `box-shadow` started about 12px outside the card and left a visible gap. The box is aligned to the card edge (`inset: 0`, matching the `.card-face` radius) so the glow hugs the card.
- `cards.css` (foil rainbow): the holographic background scrolled a 250%-wide non-repeating gradient until it ran off-screen, flashing a flat patch and snapping at the loop. It now uses a horizontal band whose first and last stops match, tiled and scrolled by exactly one image width, so it loops seamlessly.
- `sw.js`: cache version bump so clients pick up the changed assets.

## Expected behavior

- On desktop, a drawn card keeps following the cursor on hover, including after the cursor leaves and re-enters; it no longer freezes.
- The golden halo around rare cards starts at the card edge, with no gap.
- The rare-card holographic rainbow animates as a continuous loop, with no flat passes or color snap.
