### PR TITLE
fix(draw): harden preview viewer and draw-screen lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - On desktop, a drawn card no longer freezes after the cursor leaves and returns: the hover tilt keeps following the pointer instead of locking up.
 - Rare (foil) cards look cleaner: the golden halo now hugs the card instead of floating with a gap around it, and the holographic rainbow loops continuously instead of flashing a flat patch and snapping back each cycle.
+- A card opened in preview (from History or Collection) now behaves as a proper static viewer: it no longer sprouts floating hearts and ripples after you switch tabs and come back, and it no longer sends itself back to the home screen after a long idle. Those behaviors stay reserved for a live draw.
+- Leaving the draw screen while a card is still being revealed is now clean: the reveal sound and vibration no longer fire a moment later on the screen you moved to, and the "back to home after inactivity" timer no longer lingers on other screens.
 - Harmonized a few UI strings: consistent search placeholders, the admin card form now says "Tas" like the rest of the French UI, the weak-password error reuses the strength meter's wording, and an ambiguous French rules sentence ("la retirer") now clearly means the card can come back later.
 
 ## [1.10.0] - 2026-06-12

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -15,6 +15,10 @@ import { refreshHomeCounts } from '../home/home.js';
 let currentCardId = null;
 let previewMode = false;
 let previewCardId = null;
+// Bumped on each startDraw and on unmount, so an in-flight reveal animation can
+// detect that the user has left and stop before its tail (sound, vibration,
+// hearts) fires on a screen that's already gone.
+let drawGeneration = 0;
 
 const $ = (id) => document.getElementById(id);
 
@@ -67,7 +71,9 @@ function spawnHeart() {
   setTimeout(() => h.remove(), CONFIG.hearts.lifetime);
 }
 function startHearts() {
-  if (heartsInterval || prefersReducedMotion()) return;
+  // Preview is a static viewer with no ambient effects. Gating here, not just
+  // at call sites, keeps that rule in one place for every caller.
+  if (previewMode || heartsInterval || prefersReducedMotion()) return;
   const tick = () => {
     spawnHeart();
     if (Math.random() < CONFIG.hearts.doubleBeatChance) setTimeout(spawnHeart, 120);
@@ -92,6 +98,7 @@ function spawnRipple() {
   setTimeout(() => r.remove(), 1500);
 }
 function startRipples(interval) {
+  if (previewMode) return; // static preview viewer: no ambient ripples (see startHearts)
   stopRipples();
   if (prefersReducedMotion()) return;
   spawnRipple();
@@ -188,6 +195,7 @@ let tiltActive = false;
 let tiltPointerDown = null;
 let tiltPointerMove = null;
 let tiltPointerUp = null;
+let tiltPointerLeave = null;
 let orientationAttached = false;
 let orientationHandler = null;
 let isReturning = false;
@@ -411,9 +419,10 @@ function attachTilt() {
   tilt.addEventListener('pointerdown', tiltPointerDown);
   tilt.addEventListener('pointerup', tiltPointerUp);
   tilt.addEventListener('pointercancel', tiltPointerUp);
-  tilt.addEventListener('pointerleave', (e) => {
+  tiltPointerLeave = (e) => {
     if (e.pointerType === 'mouse' && !pointerDown && !orientationAttached) resetTilt();
-  });
+  };
+  tilt.addEventListener('pointerleave', tiltPointerLeave);
 
   if (orientationPermission === 'granted') attachOrientation();
 }
@@ -455,8 +464,9 @@ function detachTilt() {
     tilt.removeEventListener('pointerdown', tiltPointerDown);
     tilt.removeEventListener('pointerup', tiltPointerUp);
     tilt.removeEventListener('pointercancel', tiltPointerUp);
+    tilt.removeEventListener('pointerleave', tiltPointerLeave);
   }
-  tiltPointerMove = tiltPointerDown = tiltPointerUp = null;
+  tiltPointerMove = tiltPointerDown = tiltPointerUp = tiltPointerLeave = null;
   tiltActive = false;
   if (orientationAttached && orientationHandler) {
     window.removeEventListener('deviceorientation', orientationHandler);
@@ -488,6 +498,13 @@ function applyCardText(card) {
 
 export async function startDraw(pile) {
   previewMode = false;
+  // Claim this generation. If unmount or a newer draw bumps the counter while
+  // we await, stale() turns true and we bail; the bail itself touches no shared
+  // state (wake lock, ripples, hearts) so it can't clobber a concurrent draw,
+  // unmount having already cleaned those up. Returns true only on full
+  // completion, so mount() skips its listener setup when we bailed.
+  const myGen = ++drawGeneration;
+  const stale = () => myGen !== drawGeneration;
   const recentLimit = CONFIG.recentExclude[pile] || 3;
   const recentIds = getHistory()
     .filter((h) => { const c = getCardById(h.cardId); return c && c.pile === pile; })
@@ -497,7 +514,7 @@ export async function startDraw(pile) {
   if (!card) {
     toast(t('draw.toast.empty'));
     navigate('home');
-    return;
+    return false;
   }
   currentCardId = card.id;
 
@@ -517,6 +534,7 @@ export async function startDraw(pile) {
 
   resetStage();
   await requestWakeLock();
+  if (stale()) return false;
   playDraw();
 
   const f = $('card-flip');
@@ -535,28 +553,34 @@ export async function startDraw(pile) {
   void f.offsetWidth;
 
   await wait(30);
+  if (stale()) return false;
   f.classList.add('enter');
   await wait(reduced ? 250 : CONFIG.draw.enterDuration);
+  if (stale()) return false;
 
   if (reduced) {
     f.classList.add('flipping');
     await wait(400);
+    if (stale()) return false;
   } else {
     glow.classList.add('active');
     p.classList.add('active');
     f.classList.add('pulsing');
     startRipples(CONFIG.ripples.normalInterval);
     await wait(CONFIG.draw.pulsingDuration);
+    if (stale()) return false;
     glow.classList.add('boost');
     f.classList.remove('pulsing');
     f.classList.add('climax');
     s.classList.add('preflash');
     startRipples(CONFIG.ripples.boostInterval);
     await wait(CONFIG.draw.climaxDuration);
+    if (stale()) return false;
     stopRipples();
     f.classList.remove('climax');
     f.classList.add('flipping');
     await wait(CONFIG.draw.flipDuration);
+    if (stale()) return false;
   }
 
   f.classList.add('settled');
@@ -572,12 +596,14 @@ export async function startDraw(pile) {
   front.classList.add('idle-shine');
 
   await wait(reduced ? CONFIG.draw.reducedMotionShort : CONFIG.draw.revealDelay);
+  if (stale()) return false;
   vibrate(CONFIG.vibrations.reveal);
   playReveal(!!card.foil);
   announceCard(card);
   a.hidden = false;
   attachTilt();
   startHearts();
+  return true;
 }
 
 async function doReturn(animated = false) {
@@ -670,7 +696,7 @@ function updatePreviewActions(cardId) {
 // Invoked from the history feature to open a card in read-only preview.
 export function showCardDirectly(cardId) {
   const card = getCardById(cardId);
-  if (!card) return;
+  if (!card) return false;
   previewMode = true;
   currentCardId = null;
   previewCardId = cardId;
@@ -700,6 +726,7 @@ export function showCardDirectly(cardId) {
   // Skip the floating hearts and ambient ripples in preview mode: those are
   // tuned for the dramatic reveal flow, and replaying them every time the
   // user opens an already-known card from Collection or History feels heavy.
+  return true;
 }
 
 async function previewBan() {
@@ -764,6 +791,9 @@ function onDrawKeydown(event) {
 let inactivityTimer = 0;
 let lastInactivityBump = 0;
 function bumpInactivity() {
+  // Preview is a read-only viewer: no wake lock, no draw, so never auto-navigate
+  // the user away. The inactivity timeout is only meaningful for a live draw.
+  if (previewMode) return;
   // pointermove fires up to ~60 Hz during a tilt drag; coalesce to one bump
   // per ~500 ms so we don't clearTimeout/setTimeout on every frame.
   const now = performance.now();
@@ -794,6 +824,7 @@ function onVisibilityChange() {
   bumpInactivity();
   // Resume the ambient effects when the user is back and a card has been
   // revealed (the settled class means the flip animation has landed).
+  // startHearts/startRipples no-op in preview, so no guard is needed here.
   const settled = $('card-flip')?.classList.contains('settled');
   if (settled) {
     startHearts();
@@ -826,10 +857,13 @@ export async function mount({ params }) {
   const pile = params.get ? params.get('pile') : params.pile;
   const preview = params.get ? params.get('preview') : params.preview;
   if (preview) {
-    currentCardId = preview;
-    showCardDirectly(preview);
+    // Stale deep link or deleted card: don't strand the user on a blank screen.
+    if (!showCardDirectly(preview)) { navigate('home'); return; }
   } else if (pile === 'home' || pile === 'outdoor') {
-    await startDraw(pile);
+    // If the user navigates away mid-reveal, startDraw bails and returns false;
+    // skip the listener setup so we don't re-add document listeners after the
+    // unmount that the new navigation already ran.
+    if (!(await startDraw(pile))) return;
   } else {
     navigate('home');
     return;
@@ -848,6 +882,7 @@ export function unmount() {
   stopRipples();
   detachTilt();
   releaseWakeLock();
+  drawGeneration++; // invalidate any reveal animation still mid-await
   currentCardId = null;
   previewMode = false;
   previewCardId = null;

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards: stale-while-revalidate (allows offline viewing)
 //   * all other /api/*: network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v42';
+const VERSION = 'couplecards-v43';
 const SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary

A review pass over the draw feature (`public/js/features/deck/draw.js`) fixed four robustness gaps in the draw / preview lifecycle.

## Changes

- **Preview is a true static viewer.** Floating hearts and ripples no longer reappear after a tab switch, and the inactivity "back to home" timer no longer runs in preview. The skip rule now lives inside `startHearts`/`startRipples` so every caller is covered. A dead `currentCardId` assignment was removed.
- **Tilt listener leak.** The `pointerleave` handler is now stored and removed in `detachTilt`, so it no longer accumulates across redraws within a single visit.
- **Interrupted reveal.** `startDraw` carries a generation token and bails after each `await` if the user has left, so the reveal sound, vibration and hearts never fire on a screen that's gone. It reports completion so `mount` skips re-adding document listeners after an unmount triggered by mid-reveal navigation (which previously leaked the inactivity timer onto other screens).
- **Stale preview link.** Opening a preview for a card that no longer exists redirects to home instead of leaving a blank screen where Escape does nothing.

Service worker cache version bumped (v43) so clients pick up the changed asset.

## Expected behavior after merge

- Leaving the draw screen mid-reveal: no delayed reveal sound or vibration on the next screen, no surprise redirect to home later.
- Preview from History or Collection: no ambient hearts or ripples, no auto-redirect; opening a deleted card lands on home.
- Repeated redraws on desktop: moving the mouse off the card stays smooth.
- A normal draw is unchanged: sound, vibration, hearts and tilt all work.
