### PR TITLE
chore(release): cut version 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-06-19
+
 ### Added
 
 - Public self-registration from the sign-in page. The admin opens it with a switch in the Users tab (off by default, initial state seeded from the `ENABLE_REGISTRATION` variable); a "Create an account" link then lets anyone sign up with a username and a password of their own.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/compress": "^9.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "type": "module",
   "description": "Couplecards backend — Fastify + node:sqlite",


### PR DESCRIPTION
Release 1.11.0.

Bumps the root and server package versions to 1.11.0 and promotes `[Unreleased]` to `[1.11.0] - 2026-06-19`. No code changes in this PR.

## Highlights since 1.10.0

**Added**
- Public self-registration from the sign-in page (admin-controlled, off by default).
- Last sign-in column in the admin Users list, with one-click removal of accounts inactive for 3, 6, or 12 months.
- A "Forgot your password?" explainer and a developer / source-code footer on the sign-in screens.

**Changed**
- US spelling and a prose polish across the docs, comments, and the card deck.
- Password-strength engine (zxcvbn-ts) upgraded to v4; minimum-strength requirements unchanged.
- Collection grid lazy-loads off-screen card icons.

**Fixed**
- Card icons now work offline across the whole deck, plus desktop hover-tilt, foil, preview-viewer, draw-lifecycle, and duplicate-username fixes.

## After merge

Pushing the `v1.11.0` tag triggers `.github/workflows/release.yml`, which builds and publishes the multi-arch Docker image to ghcr. I will tag and watch that run once you confirm the merge.
