### PR TITLE
fix: durable undo, migration data-loss guard, lockout and demo fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,10 @@
 .git
 .github
 .gitignore
-.env
-.env.*
+**/.env
+**/.env.*
 !.env.example
-var/
+**/var/
 **/node_modules
 **/npm-debug.log
 **/.DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,14 @@ jobs:
       - name: Build Docker image
         run: docker build --build-arg VERSION=ci --build-arg REVISION=${{ github.sha }} -t couplecards:ci .
 
+      # The root package.json only has devDependencies, but those are exactly
+      # the libraries bundled into public/vendor/ and shipped to browsers, so
+      # install them and check without --production.
+      - name: Install root dependencies
+        run: npm ci --no-audit --no-fund
+
       - name: Check root dependency licenses
-        run: npx --yes license-checker --production --onlyAllow 'MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;OFL-1.1;CC0-1.0;Unlicense;0BSD;BlueOak-1.0.0' --excludePrivatePackages
+        run: npx --yes license-checker --onlyAllow 'MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;OFL-1.1;CC0-1.0;Unlicense;0BSD;BlueOak-1.0.0' --excludePrivatePackages
 
       - name: Check server dependency licenses
         working-directory: server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Undo now sticks. Tapping "Undo" on the ban or return toast previously only reverted the change locally, so the entry silently came back in History and Collection on the next reload; the undo now also removes it on the server, including when it happens offline.
+- Database migrations that rebuild a table can no longer cascade-delete user data. The migration that added German, Italian, and Spanish did exactly that: instances that upgraded through it lost their banned cards and play history.
+- Once an account lockout expires, the failed-attempt counter resets, so a single wrong password no longer re-locks the account for another full period.
+- The shared demo account no longer remembers the previous visitor's language choice.
+- Switching screens in quick succession can no longer show the wrong screen: the router now discards a navigation that was overtaken by a newer one.
+- Tapping a pile and then a navigation link during the short launch animation no longer yanks you to the draw screen afterward.
+- The change-password dialog in Settings now behaves like the other dialogs: Escape and clicking outside close it, keyboard focus stays trapped inside, and focus returns to the control that opened it.
+- The password-strength meter shown on the forced first-login change now follows the server's configured strength policy instead of a hardcoded threshold.
+- The app manifest is now part of the offline cache, so the installed app keeps its name and icons offline right after an update.
+- Docker builds run from a working copy no longer bake the local development database (`server/var/`) into the image.
+
+### Changed
+
+- The CI license check now installs the root dependencies before running, so the libraries actually bundled for browsers (zxcvbn, fflate) are checked; the step previously inspected an empty tree and verified nothing.
+- The backup documentation now covers WAL mode properly: a hot copy must include the `-wal` and `-shm` companion files, and stopping the container first remains the reliable method.
+
 ## [1.11.0] - 2026-06-19
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,7 +118,7 @@ Four guard levels are referenced below: **public** (no auth needed), **session**
 | `POST` | `/api/auth/logout` | session | |
 | `GET` | `/api/auth/me` | public | Returns 401 when no session |
 | `POST` | `/api/auth/change-password` | session | Rotates `session_epoch` |
-| `POST` | `/api/auth/preferences` | session | Updates the locale |
+| `POST` | `/api/auth/preferences` | session | Updates the locale. Acknowledged but not persisted for demo accounts |
 | `GET` | `/api/cards` | session | Returns each card with `translations` keyed by locale. ETag-aware, 304 when unchanged |
 | `POST`, `PATCH`, `DELETE` | `/api/cards[/:id]` | admin | Per-card CRUD. The body carries a `translations` map of `{ locale: { title, description } }` |
 | `GET` | `/api/admin/cards/export` | admin | Downloads a ZIP with one `cards.<locale>.json` per supported locale, pretty-printed |
@@ -127,7 +127,7 @@ Four guard levels are referenced below: **public** (no auth needed), **session**
 | `GET` | `/api/state` | user | Returns `{ banned, history }` |
 | `POST` | `/api/state/reset` | user | Wipes the caller's bans and history in a single transaction. Rejected with 403 for demo accounts |
 | `POST`, `DELETE` | `/api/bans[/:cardId]` | user | Idempotent |
-| `POST` | `/api/history` | user | Batch endpoint, idempotent on `clientUuid` |
+| `POST`, `DELETE` | `/api/history[/:clientUuid]` | user | Batch add and per-entry delete (undo), both idempotent on `clientUuid` |
 | `GET`, `POST`, `PATCH`, `DELETE` | `/api/admin/users[/:id]` | admin | Full user CRUD plus unlock, reset-password, and bulk removal of inactive accounts (`POST /api/admin/users/prune-inactive`) |
 | `GET`, `PUT` | `/api/admin/registration` | admin | Reads or sets the public-registration switch |
 | `GET` | `/manifest.webmanifest` | public | Negotiated on `Accept-Language` |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -50,21 +50,24 @@ Docker creates missing bind-mount directories as root by default, which is why t
 
 ### Manual backup
 
-```bash
-cp ./var/couplecards.db ./backup-$(date +%F).db
-```
-
-The database runs in WAL mode. Copying the file while the server is running is safe, although the copy may miss the last in-memory write. For strict consistency, stop the container first:
+The database runs in WAL mode: the most recent committed writes live in `couplecards.db-wal` next to the main file until SQLite folds them in. A copy of `couplecards.db` alone can therefore miss recent data, or even be unreadable if the copy races a checkpoint. The reliable method is to stop the container first (the server folds the WAL into the main file on graceful shutdown):
 
 ```bash
 docker compose down
-cp ./var/couplecards.db ./backup.db
+cp ./var/couplecards.db ./backup-$(date +%F).db
 docker compose up -d
+```
+
+To back up without downtime, copy the database together with its companion files and keep the whole set:
+
+```bash
+mkdir -p ./backups
+cp ./var/couplecards.db* ./backups/
 ```
 
 ### Restore
 
-Stop the container, replace `./var/couplecards.db` with the backup, and start the container again. Existing sessions remain valid as long as `SESSION_SECRET` has not changed.
+Stop the container, replace `./var/couplecards.db` with the backup, and delete any leftover `couplecards.db-wal` and `couplecards.db-shm` files (or restore them alongside if your backup includes them). Then start the container again. Existing sessions remain valid as long as `SESSION_SECRET` has not changed.
 
 ## Emergency admin reset
 

--- a/public/js/core/router.js
+++ b/public/js/core/router.js
@@ -14,6 +14,10 @@ let currentRoute = null;
 let currentModule = null;
 let outlet = null;
 let isHistoryNav = false;
+// Bumped on every render() call. Each await inside render() re-checks it so a
+// render overtaken by a newer navigation stops instead of overwriting the
+// newer view with its own stale partial, module, scroll reset, and focus.
+let renderGen = 0;
 
 export function registerFeature(name, loader) {
   features.set(name, loader);
@@ -56,6 +60,7 @@ export async function render() {
   if (!outlet) return;
   const { segment, params } = parsePath();
   if (!features.has(segment)) return;
+  const gen = ++renderGen;
 
   // Snapshot the scroll position of the screen we are about to leave, so a
   // future browser back can restore it.
@@ -66,16 +71,21 @@ export async function render() {
   if (currentModule && typeof currentModule.unmount === 'function') {
     try { currentModule.unmount(); } catch (err) { console.error('unmount failed', err); }
   }
+  // Null right away so an overlapping render cannot unmount the same module twice.
+  currentModule = null;
 
   const html = await loadPartial(segment);
+  if (gen !== renderGen) return;
   outlet.innerHTML = html;
   applyI18n(outlet);
 
   const module = await features.get(segment)();
+  if (gen !== renderGen) return;
   currentModule = module;
   currentRoute = segment;
   if (module && typeof module.mount === 'function') {
     await module.mount({ params, outlet });
+    if (gen !== renderGen) return;
   }
   document.dispatchEvent(new CustomEvent('route:mounted', { detail: { route: segment } }));
 

--- a/public/js/core/sync.js
+++ b/public/js/core/sync.js
@@ -247,14 +247,26 @@ export async function addHistory(entry) {
   return full;
 }
 
-// Remove a history entry locally by its clientUuid. Used by the ban-undo flow
-// so reverting a ban also removes the matching history row.
+// Remove a history entry by its clientUuid. Used by the undo flows: the entry
+// must disappear locally, from any not-yet-flushed outbox item, and from the
+// server (the flush usually wins the race against the 5 s undo toast). The
+// queued delete is idempotent, so replaying it or deleting an entry that
+// never reached the server is harmless.
 export async function removeHistoryByUuid(clientUuid) {
   const before = history.length;
   history = history.filter((e) => e.clientUuid !== clientUuid);
   if (history.length === before) return;
   await idb.setHistory(history);
   emit('state:history-changed');
+  const pending = await idb.listOutbox();
+  for (const item of pending) {
+    if (item.kind === 'history' && item.entry?.clientUuid === clientUuid) {
+      await idb.removeOutbox(item.id);
+    }
+  }
+  await idb.enqueue({ kind: 'history-delete', clientUuid });
+  notifyOutboxChanged();
+  flushOutbox().catch(() => {});
 }
 
 export async function resetUserData() {
@@ -296,11 +308,16 @@ async function flushOutbox() {
     if (!items.length) return;
     // Split into history (already a single batched POST) and ban/unban (group
     // by cardId so concurrent groups don't reorder ban+unban on the same card).
+    // History deletes run after the history batch: a delete is always enqueued
+    // after the add it undoes, so adds-then-deletes preserves the final state.
     const historyBatch = [];
+    const historyDeletes = [];
     const byCard = new Map();
     for (const item of items) {
       if (item.kind === 'history') {
         historyBatch.push({ item, entry: item.entry });
+      } else if (item.kind === 'history-delete') {
+        historyDeletes.push(item);
       } else if (item.kind === 'ban' || item.kind === 'unban') {
         if (!byCard.has(item.cardId)) byCard.set(item.cardId, []);
         byCard.get(item.cardId).push(item);
@@ -314,8 +331,11 @@ async function flushOutbox() {
     });
     try {
       await Promise.all(groups);
-    } catch (err) {
-      if (err?.status === 401) return;
+    } catch {
+      // A chain failed (401 or transient error); the other chains may have
+      // drained items, so refresh the pending badge before bailing. The next
+      // online event retries the rest.
+      notifyOutboxChanged();
       return;
     }
     if (historyBatch.length > 0) {
@@ -331,6 +351,15 @@ async function flushOutbox() {
         // The ban chains above may have drained, so refresh the pending badge,
         // but don't announce a clean flush while history entries are still
         // queued. The next online event retries them.
+        notifyOutboxChanged();
+        return;
+      }
+    }
+    for (const item of historyDeletes) {
+      try {
+        await request(`/api/history/${encodeURIComponent(item.clientUuid)}`, { method: 'DELETE' });
+        await idb.removeOutbox(item.id);
+      } catch {
         notifyOutboxChanged();
         return;
       }

--- a/public/js/features/admin/cards.js
+++ b/public/js/features/admin/cards.js
@@ -273,12 +273,10 @@ export async function mount() {
     const id = btn.dataset.id;
     try {
       if (btn.dataset.action === 'edit') {
-        const cards = await loadCards();
-        const card = cards.find((c) => c.id === id);
+        const card = allCards.find((c) => c.id === id);
         if (card) openCardDialog({ card });
       } else if (btn.dataset.action === 'delete') {
-        const cards = await loadCards();
-        const card = cards.find((c) => c.id === id);
+        const card = allCards.find((c) => c.id === id);
         if (card) {
           const { title } = getCardText(card, getLocale());
           await deleteCard(id, title || id);

--- a/public/js/features/home/home.js
+++ b/public/js/features/home/home.js
@@ -9,6 +9,7 @@ import { on } from '../../core/events.js';
 
 let unsubscribe = null;
 let pileLaunching = false;
+let pileLaunchTimer = 0;
 
 export function refreshHomeCounts() {
   const remaining = countsByPile();
@@ -59,7 +60,7 @@ export async function mount() {
       await requestOrientationIfNeeded();
       btn.classList.add('launching');
       const pile = btn.dataset.pile;
-      setTimeout(() => {
+      pileLaunchTimer = setTimeout(() => {
         btn.classList.remove('launching');
         pileLaunching = false;
         navigate('draw', { pile });
@@ -74,5 +75,8 @@ export async function mount() {
 
 export function unmount() {
   if (unsubscribe) { unsubscribe(); unsubscribe = null; }
+  // Kill a pending pile launch: navigating away inside the 380 ms launch
+  // window must not yank the user back to the draw screen.
+  clearTimeout(pileLaunchTimer);
   pileLaunching = false;
 }

--- a/public/js/features/settings/settings.js
+++ b/public/js/features/settings/settings.js
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // User settings: language, vibrations, change password, logout, install PWA.
 
-import { areVibrationsEnabled, setVibrationsEnabled, areSoundsEnabled, setSoundsEnabled, canInstall, triggerInstall, toast, showConfirm } from '../../ui/shell.js';
+import { areVibrationsEnabled, setVibrationsEnabled, areSoundsEnabled, setSoundsEnabled, canInstall, triggerInstall, toast, showConfirm, withModal } from '../../ui/shell.js';
 import { logout, setPreferences, getCachedUser, me, changePassword, getPasswordPolicy } from '../../core/auth.js';
 import { errorMessage } from '../../core/api.js';
 import { resetUserData } from '../../core/sync.js';
@@ -127,70 +127,55 @@ async function openChangePasswordDialog() {
   const user = getCachedUser() || await me();
   if (!user) { navigate('home'); return; }
   const policy = await getPasswordPolicy().catch(() => null);
-  const host = document.getElementById('modal');
-  const titleEl = document.getElementById('modal-title');
-  const bodyEl = document.getElementById('modal-body');
-  const confirmBtn = document.getElementById('modal-confirm');
-  const cancelBtn = document.getElementById('modal-cancel');
-  if (!host || !titleEl || !bodyEl || !confirmBtn || !cancelBtn) return;
-
-  titleEl.textContent = t('changePassword.title');
-  bodyEl.innerHTML = `
-    <form id="cp-form" class="change-password-form" novalidate>
-      <label class="field">
-        <span>${t('changePassword.current')}</span>
-        <input type="password" id="cp-current" autocomplete="current-password" required>
-      </label>
-      <label class="field">
-        <span>${t('changePassword.new')}</span>
-        <input type="password" id="cp-new" autocomplete="new-password" required minlength="12">
-      </label>
-      <div id="cp-strength"></div>
-      <label class="field">
-        <span>${t('changePassword.confirm')}</span>
-        <input type="password" id="cp-confirm" autocomplete="new-password" required minlength="12">
-      </label>
-      <div class="cp-error" id="cp-error" role="alert"></div>
-    </form>
-  `;
-  confirmBtn.textContent = t('changePassword.submit');
-  cancelBtn.textContent = t('common.cancel');
-  confirmBtn.classList.add('btn-primary');
-  confirmBtn.classList.remove('btn-danger');
-  cancelBtn.hidden = false;
-  host.hidden = false;
-
   const minScore = user.role === 'admin' ? (policy?.zxcvbnMinScoreAdmin ?? 4) : (policy?.zxcvbnMinScoreUser ?? 3);
-  const input = document.getElementById('cp-new');
-  const strengthHost = document.getElementById('cp-strength');
-  const unbind = bindPasswordStrength({ input, host: strengthHost, userInputs: [user.username], minScore });
 
-  const close = () => {
-    host.hidden = true;
-    unbind();
-    confirmBtn.removeEventListener('click', onConfirm);
-    cancelBtn.removeEventListener('click', onCancel);
-  };
-  const onCancel = () => close();
-  const onConfirm = async () => {
-    const current = document.getElementById('cp-current').value;
-    const next = input.value;
-    const confirm = document.getElementById('cp-confirm').value;
-    const err = document.getElementById('cp-error');
-    err.textContent = '';
-    if (next !== confirm) { err.textContent = t('changePassword.mismatch'); return; }
-    confirmBtn.disabled = true;
-    try {
-      await changePassword(current, next);
-      close();
-      toast(t('changePassword.success'));
-    } catch (e) {
-      err.textContent = errorMessage(e);
-    } finally {
-      confirmBtn.disabled = false;
-    }
-  };
-  confirmBtn.addEventListener('click', onConfirm);
-  cancelBtn.addEventListener('click', onCancel);
-  setTimeout(() => document.getElementById('cp-current')?.focus(), 50);
+  withModal({
+    title: t('changePassword.title'),
+    bodyHtml: `
+      <form id="cp-form" class="change-password-form" novalidate>
+        <label class="field">
+          <span>${t('changePassword.current')}</span>
+          <input type="password" id="cp-current" autocomplete="current-password" required>
+        </label>
+        <label class="field">
+          <span>${t('changePassword.new')}</span>
+          <input type="password" id="cp-new" autocomplete="new-password" required minlength="12">
+        </label>
+        <div id="cp-strength"></div>
+        <label class="field">
+          <span>${t('changePassword.confirm')}</span>
+          <input type="password" id="cp-confirm" autocomplete="new-password" required minlength="12">
+        </label>
+        <div class="cp-error" id="cp-error" role="alert"></div>
+      </form>
+    `,
+    confirmLabel: t('changePassword.submit'),
+    cancelLabel: t('common.cancel'),
+    onBodyReady: () => {
+      bindPasswordStrength({
+        input: document.getElementById('cp-new'),
+        host: document.getElementById('cp-strength'),
+        userInputs: [user.username],
+        minScore,
+      });
+    },
+    onConfirm: async ({ close, confirmBtn }) => {
+      const current = document.getElementById('cp-current').value;
+      const next = document.getElementById('cp-new').value;
+      const confirm = document.getElementById('cp-confirm').value;
+      const err = document.getElementById('cp-error');
+      err.textContent = '';
+      if (next !== confirm) { err.textContent = t('changePassword.mismatch'); return; }
+      confirmBtn.disabled = true;
+      try {
+        await changePassword(current, next);
+        close();
+        toast(t('changePassword.success'));
+      } catch (e) {
+        err.textContent = errorMessage(e);
+      } finally {
+        confirmBtn.disabled = false;
+      }
+    },
+  });
 }

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -37,7 +37,7 @@ function redirectAfterAuth(user) {
   location.replace(user?.role === 'admin' ? '/admin.html' : '/');
 }
 
-function showChangeStep(user) {
+function showChangeStep(user, policy) {
   showStep('change');
   $('change-title').textContent = t('changePassword.title');
   $('change-subtitle').textContent = user.mustChangePassword
@@ -48,7 +48,7 @@ function showChangeStep(user) {
     input: $('change-new'),
     host: $('change-strength'),
     userInputs: [user.username],
-    minScore: user.role === 'admin' ? 4 : 3,
+    minScore: user.role === 'admin' ? (policy?.zxcvbnMinScoreAdmin ?? 4) : (policy?.zxcvbnMinScoreUser ?? 3),
   });
 
   $('change-form').addEventListener('submit', async (e) => {
@@ -74,12 +74,12 @@ async function init() {
   await initI18n(existing?.locale);
   applyI18n(document);
 
-  await getPasswordPolicy().catch(() => null);
+  const policy = await getPasswordPolicy().catch(() => null);
 
   const params = new URLSearchParams(location.search);
   if (existing) {
     if (existing.mustChangePassword || params.get('forceChange')) {
-      showChangeStep(existing);
+      showChangeStep(existing, policy);
       return;
     }
     redirectAfterAuth(existing);
@@ -104,7 +104,7 @@ async function init() {
     try {
       const user = await login(username, password);
       if (user.mustChangePassword) {
-        showChangeStep(user);
+        showChangeStep(user, policy);
       } else {
         redirectAfterAuth(user);
       }

--- a/public/js/ui/floating-bg.js
+++ b/public/js/ui/floating-bg.js
@@ -67,8 +67,11 @@ export function mountFloatingBackground(count = 22) {
 
   const apply = () => {
     rafId = 0;
-    for (const el of items) {
-      const r = el.getBoundingClientRect();
+    // Read all rects first, then write styles: interleaving the two forces a
+    // layout recalculation per item on every frame.
+    const rects = items.map((el) => el.getBoundingClientRect());
+    items.forEach((el, i) => {
+      const r = rects[i];
       const cx = r.left + r.width / 2;
       const cy = r.top + r.height / 2;
       const dx = cx - mx;
@@ -84,7 +87,7 @@ export function mountFloatingBackground(count = 22) {
         el.style.setProperty('--repel-y', '0px');
         el.style.setProperty('--repel-opacity', '');
       }
-    }
+    });
   };
 
   window.addEventListener('mousemove', (e) => {

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,10 +4,11 @@
 //   * /api/cards: stale-while-revalidate (allows offline viewing)
 //   * all other /api/*: network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v46';
+const VERSION = 'couplecards-v47';
 const SHELL = [
   '/',
   '/index.html',
+  '/manifest.webmanifest',
   '/login.html',
   '/register.html',
   '/forgot-password.html',
@@ -113,7 +114,9 @@ self.addEventListener('message', (event) => {
 });
 
 function isAuthSensitive(pathname) {
-  if (pathname === '/api/cards' || pathname.startsWith('/api/cards/')) return false;
+  // Exact match only: any future GET under /api/cards/... must stay
+  // network-only rather than fall through to cache-first below.
+  if (pathname === '/api/cards') return false;
   return pathname.startsWith('/api/');
 }
 
@@ -159,17 +162,4 @@ async function staleWhileRevalidate(request) {
     return resp;
   }).catch(() => null);
   return cached || fetched || Response.error();
-}
-
-self.addEventListener('sync', (event) => {
-  if (event.tag === 'couplecards-outbox-flush') {
-    event.waitUntil(broadcastFlush());
-  }
-});
-
-async function broadcastFlush() {
-  const clients = await self.clients.matchAll({ includeUncontrolled: true });
-  for (const client of clients) {
-    client.postMessage({ type: 'OUTBOX_FLUSH' });
-  }
 }

--- a/server/migrations/005_index_housekeeping.sql
+++ b/server/migrations/005_index_housekeeping.sql
@@ -1,0 +1,10 @@
+-- SPDX-License-Identifier: MIT
+-- Drop idx_users_username: the UNIQUE COLLATE NOCASE constraint on
+-- users.username already creates an equivalent implicit index, so the
+-- explicit one only duplicates writes.
+-- Add an index on bans.card_id: the bans primary key is (user_id, card_id),
+-- which cannot serve lookups by card alone, so every card deletion (single,
+-- bulk, mirror sync) full-scans bans to enforce the ON DELETE CASCADE.
+
+DROP INDEX IF EXISTS idx_users_username;
+CREATE INDEX idx_bans_card_id ON bans(card_id);

--- a/server/src/db/migrate.js
+++ b/server/src/db/migrate.js
@@ -33,10 +33,24 @@ export function runMigrations(logger) {
   for (const file of files) {
     if (applied.has(file)) continue;
     const sql = readFileSync(resolve(MIGRATIONS_DIR, file), 'utf8');
-    transaction(() => {
-      db.exec(sql);
-      record.run(file);
-    })();
+    // Rebuild-style migrations (CREATE new table, copy, DROP old) must run
+    // with foreign keys off: with the pragma on, dropping the old table fires
+    // ON DELETE CASCADE on referencing tables and silently wipes their rows.
+    // The pragma is a no-op inside a transaction, so toggle it outside the
+    // BEGIN/COMMIT and re-check referential integrity before committing.
+    db.exec('PRAGMA foreign_keys = OFF');
+    try {
+      transaction(() => {
+        db.exec(sql);
+        const violations = db.prepare('PRAGMA foreign_key_check').all();
+        if (violations.length > 0) {
+          throw new Error(`migration ${file} leaves ${violations.length} foreign key violation(s)`);
+        }
+        record.run(file);
+      })();
+    } finally {
+      db.exec('PRAGMA foreign_keys = ON');
+    }
     logger?.info({ migration: file }, 'applied migration');
   }
 }

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -10,9 +10,8 @@ import { SUPPORTED_LOCALES } from '../lib/locales.js';
 const LOCKOUT_THRESHOLD = 10;
 const LOCKOUT_MINUTES = 15;
 
-const passwordSchema = { type: 'string', minLength: 8, maxLength: 200 };
-// Self-registration requires the full policy length up front: there is no
-// generated password to change later, the user picks their own.
+// Matches POLICY.minLength: both registration and change-password enforce the
+// full policy on the new password anyway, the schema just fails cheap and early.
 const newPasswordSchema = { type: 'string', minLength: 12, maxLength: 200 };
 // Login and the `currentPassword` field of change-password accept any
 // non-empty value: the strength policy is enforced on the new password, and
@@ -83,6 +82,13 @@ export default async function authRoutes(app) {
       if (unlockAt > new Date()) {
         return reply.code(423).send({ error: 'ACCOUNT_LOCKED', details: { unlockAt: unlockAt.toISOString() } });
       }
+      // Lock expired: restore a full window of attempts. Without this reset
+      // the counter stays at the threshold and a single wrong password
+      // re-locks the account for another full period, indefinitely.
+      db.prepare(`
+        UPDATE users SET failed_attempts = 0, locked_until = NULL, updated_at = datetime('now')
+        WHERE id = ?
+      `).run(row.id);
     }
 
     const ok = await verifyPassword(row.password_hash, password);
@@ -218,7 +224,7 @@ export default async function authRoutes(app) {
         additionalProperties: false,
         properties: {
           currentPassword: currentPasswordSchema,
-          newPassword: passwordSchema,
+          newPassword: newPasswordSchema,
         },
       },
     },
@@ -270,6 +276,9 @@ export default async function authRoutes(app) {
   }, async (request) => {
     const { locale } = request.body;
     if (!locale) return { ok: true };
+    // Shared demo account: acknowledge without persisting, one visitor's
+    // locale choice must not leak to the next (login only wipes bans/history).
+    if (request.currentUser.isDemo) return { ok: true };
     getDb().prepare(`
       UPDATE users SET locale = ?, updated_at = datetime('now')
       WHERE id = ?

--- a/server/src/routes/sync.js
+++ b/server/src/routes/sync.js
@@ -134,4 +134,24 @@ export default async function syncRoutes(app) {
     })(request.body.entries);
     return { ok: true };
   });
+
+  // Undo support: drop a single entry by its client-generated uuid. Idempotent
+  // like the other mutations, so the outbox can replay it and deleting an
+  // entry that never reached the server is a harmless no-op.
+  app.delete('/history/:clientUuid', {
+    schema: {
+      params: {
+        type: 'object',
+        required: ['clientUuid'],
+        additionalProperties: false,
+        properties: {
+          clientUuid: { type: 'string', minLength: 8, maxLength: 64 },
+        },
+      },
+    },
+  }, async (request) => {
+    getDb().prepare('DELETE FROM history WHERE user_id = ? AND client_uuid = ?')
+      .run(request.currentUser.id, request.params.clientUuid);
+    return { ok: true };
+  });
 }


### PR DESCRIPTION
Fixes from a full review of the server and client code: three data-affecting bugs, several robustness and accessibility gaps, and a few build and CI corrections.

## Data integrity

- Migrations now run with foreign keys disabled and check referential integrity before committing. Rebuild-style migrations used to fire ON DELETE CASCADE when dropping the old table: migration 002 wiped bans and history on every instance that upgraded through it. Verified empirically: a database with only 001 applied plus user data now goes through 002-005 with all rows intact.
- Undo after a draw is now durable. The toast undo only reverted local state while the action had already been flushed, so the entry returned on the next state load. Undo now purges the pending outbox item and issues an idempotent `DELETE /api/history/:clientUuid` (new route, covered offline through the outbox).
- Local Docker builds no longer bake `server/var/` (dev database) into the image; `.dockerignore` patterns are context-root-relative so `var/` did not cover it.

## Behavior fixes

- Expired lockouts reset the failed-attempt counter; previously one wrong password re-locked the account for another 15 minutes, indefinitely.
- The demo account acknowledges locale changes without persisting them, so one visitor's choice no longer leaks to the next.
- The SPA router discards renders overtaken by a newer navigation instead of overwriting the newer view.
- A pending pile-launch timer is cancelled on unmount so quick navigation is no longer yanked to the draw screen.
- The Settings change-password dialog is rebuilt on `withModal()`: Escape, backdrop click, focus trap, and focus restore now work like the other dialogs.
- The forced first-login password meter follows the server policy instead of hardcoded thresholds.

## Maintenance

- CI installs the root dependencies before the license check; the step previously inspected an empty tree.
- Service worker: manifest precached, dead background-sync plumbing removed, `/api/cards` cache exemption made exact.
- Migration 005 drops the redundant `idx_users_username` and indexes `bans.card_id` for the delete cascades.
- Backup docs now cover WAL mode (copy the `-wal`/`-shm` companions, or stop the container first).

## Expected behaviors after merge

- Undoing a ban or return survives a reload, online and offline.
- A user whose lockout expired gets 10 fresh attempts.
- Existing instances upgrade cleanly; migration 005 applies on boot.
- Wrong-screen flashes during rapid navigation are gone.

Verified locally: syntax checks on all touched files, a migration regression test (v1.0-shaped database with data upgraded through all migrations without loss), and 10 API tests against a live dev server (lockout reset, demo locale guard, history delete) all pass.
