### PR TITLE
fix: nginx CSP passthrough, duplicate-card 409, reduced-motion and admin fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - The password-strength meter shown on the forced first-login change now follows the server's configured strength policy instead of a hardcoded threshold.
 - The app manifest is now part of the offline cache, so the installed app keeps its name and icons offline right after an update.
 - Docker builds run from a working copy no longer bake the local development database (`server/var/`) into the image.
+- The bundled nginx configuration no longer strips the app's Content-Security-Policy and Permissions-Policy headers; deployments based on it were running without CSP.
+- Creating a card whose identifier already exists shows the proper "identifier already in use" message again instead of a generic server error.
+- The admin Users tab shows creation and last sign-in times in the viewer's timezone; they were shifted by the UTC offset.
+- "Reduce motion" now also covers the full-screen reveal flash, the revealed card's looping shine, and the screen slide-in animation.
+- Switching tabs and back on a revealed card no longer restarts ripple effects that had already finished, and a leftover card-return animation can no longer freeze the tilt effect on the next draw.
+- `ENABLE_REGISTRATION` set in `.env` now actually reaches the container, and the HTTPS deployment variants also pass `ADMIN_RESET` and `ENABLE_DEMO_ACCOUNT` through, so the documented recovery and demo switches work without editing the compose file.
+- Two deck edits saved within the same second no longer leave clients on the stale text: the deck version now includes a persistent revision counter.
+- The container healthcheck follows a custom `PORT` instead of assuming 3000.
 
 ### Changed
+
+- The Docker image is roughly half as large: file ownership is set during copy instead of in a duplicating chown layer.
+- `/api/health` no longer exposes the app version publicly; it only reports liveness.
+- Seed files are validated at first boot with the same rules as the admin "sync from files" operation; malformed files are skipped with a warning instead of seeding unvalidated data.
+- Switching the admin panel language re-renders the lists from memory instead of refetching them.
 
 - The CI license check now installs the root dependencies before running, so the libraries actually bundled for browsers (zxcvbn, fflate) are checked; the step previously inspected an empty tree and verified nothing.
 - The backup documentation now covers WAL mode properly: a hot copy must include the `-wal` and `-shm` companion files, and stopping the container first remains the reliable method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `/api/health` no longer exposes the app version publicly; it only reports liveness.
 - Seed files are validated at first boot with the same rules as the admin "sync from files" operation; malformed files are skipped with a warning instead of seeding unvalidated data.
 - Switching the admin panel language re-renders the lists from memory instead of refetching them.
-
 - The CI license check now installs the root dependencies before running, so the libraries actually bundled for browsers (zxcvbn, fflate) are checked; the step previously inspected an empty tree and verified nothing.
 - The backup documentation now covers WAL mode properly: a hot copy must include the `-wal` and `-shm` companion files, and stopping the container first remains the reliable method.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ The bundled fonts are Inter for the sans-serif stack and Fraunces for the serif 
 - Keep commits small and focused. One concern per pull request.
 - Write the commit subject in imperative English, for example `Add sync outbox`.
 - Reference related issues by number in the commit body when relevant.
-- Every new source file must carry an SPDX header on its first line. The `scripts/add-spdx.mjs` helper can retrofit existing files.
+- Every new source file must carry an SPDX header on its first line (`// SPDX-License-Identifier: MIT`).
 
 ## Security
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,16 +46,18 @@ ENV NODE_ENV=production \
     PUBLIC_DIR=/app/public \
     DATA_SEED_DIR=/app/data
 
-COPY --from=backend-deps /build/node_modules ./server/node_modules
-COPY server ./server
-COPY --from=vendor /build/public ./public
-COPY data ./data
+# --chown on the COPY lines: a separate `chown -R /app` RUN would rewrite
+# every copied file into an extra layer and roughly double the image size.
+COPY --from=backend-deps --chown=app:app /build/node_modules ./server/node_modules
+COPY --chown=app:app server ./server
+COPY --from=vendor --chown=app:app /build/public ./public
+COPY --chown=app:app data ./data
 
-RUN mkdir -p /app/var && chown -R app:app /app
+RUN mkdir -p /app/var && chown app:app /app/var
 USER app
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-  CMD ["node", "-e", "fetch('http://127.0.0.1:3000/api/health').then((r) => process.exit(r.ok ? 0 : 1), () => process.exit(1))"]
+  CMD ["node", "-e", "fetch('http://127.0.0.1:' + (process.env.PORT || 3000) + '/api/health').then((r) => process.exit(r.ok ? 0 : 1), () => process.exit(1))"]
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["node", "server/src/index.js"]

--- a/deploy/caddy/docker-compose.caddy.yml
+++ b/deploy/caddy/docker-compose.caddy.yml
@@ -16,6 +16,9 @@ services:
       COOKIE_SECURE: "true"
       TRUST_PROXY: "1"
       SEED_LOCALE: ${SEED_LOCALE:-en}
+      ADMIN_RESET: ${ADMIN_RESET:-0}
+      ENABLE_DEMO_ACCOUNT: ${ENABLE_DEMO_ACCOUNT:-0}
+      ENABLE_REGISTRATION: ${ENABLE_REGISTRATION:-0}
     volumes:
       - ../../var:/app/var
 

--- a/deploy/nginx/docker-compose.nginx.yml
+++ b/deploy/nginx/docker-compose.nginx.yml
@@ -15,6 +15,9 @@ services:
       COOKIE_SECURE: "true"
       TRUST_PROXY: "1"
       SEED_LOCALE: ${SEED_LOCALE:-en}
+      ADMIN_RESET: ${ADMIN_RESET:-0}
+      ENABLE_DEMO_ACCOUNT: ${ENABLE_DEMO_ACCOUNT:-0}
+      ENABLE_REGISTRATION: ${ENABLE_REGISTRATION:-0}
     volumes:
       - ../../var:/app/var
 

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -20,10 +20,6 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers off;
 
-    # Let the app manage its own CSP/Permissions-Policy headers.
-    proxy_hide_header Permissions-Policy;
-    proxy_hide_header Content-Security-Policy;
-
     location / {
         proxy_pass http://couplecards:3000;
         proxy_set_header Host $host;

--- a/deploy/traefik/docker-compose.traefik.yml
+++ b/deploy/traefik/docker-compose.traefik.yml
@@ -38,6 +38,9 @@ services:
       COOKIE_SECURE: "true"
       TRUST_PROXY: "1"
       SEED_LOCALE: ${SEED_LOCALE:-en}
+      ADMIN_RESET: ${ADMIN_RESET:-0}
+      ENABLE_DEMO_ACCOUNT: ${ENABLE_DEMO_ACCOUNT:-0}
+      ENABLE_REGISTRATION: ${ENABLE_REGISTRATION:-0}
     volumes:
       - ../../var:/app/var
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,6 @@ services:
       SEED_LOCALE: ${SEED_LOCALE:-en}
       ADMIN_RESET: ${ADMIN_RESET:-0}
       ENABLE_DEMO_ACCOUNT: ${ENABLE_DEMO_ACCOUNT:-0}
+      ENABLE_REGISTRATION: ${ENABLE_REGISTRATION:-0}
     volumes:
       - ./var:/app/var

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "node": ">=24.0.0"
   },
   "scripts": {
-    "build:vendor": "node scripts/build-vendor.mjs",
-    "add-spdx": "node scripts/add-spdx.mjs"
+    "build:vendor": "node scripts/build-vendor.mjs"
   },
   "devDependencies": {
     "@zxcvbn-ts/core": "^4.1.2",

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -948,10 +948,10 @@
   .ripple { animation: none; opacity: 0; }
   .burst.active .shard { animation: none; opacity: 0; }
   #screen-draw.preflash::before { animation: none; }
+  #screen-draw.flash::after { animation: none; }
   .card-flip.glow-home::after,
   .card-flip.glow-outdoor::after { animation: none; }
-  .card-back-crest { animation: none; }
-  .card-shine { animation: none; opacity: 0; }
+  .card-front.idle-shine::before { animation: none; opacity: 0; }
 
   @keyframes card-enter-rm {
     from { opacity: 0; }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -160,6 +160,12 @@ body::before {
   to   { opacity: 1; transform: translateX(0); }
 }
 
+/* Placed after the .screen rule above: same specificity, so source order is
+   what lets this override win under reduced motion. */
+@media (prefers-reduced-motion: reduce) {
+  .screen { animation: none; }
+}
+
 /* View Transitions API (Chromium / Safari 18+): smooth crossfade between screens */
 @media (prefers-reduced-motion: no-preference) {
   ::view-transition-old(root),

--- a/public/js/core/i18n.js
+++ b/public/js/core/i18n.js
@@ -2,7 +2,7 @@
 // Tiny i18n helper: JSON catalogues, {{param}} interpolation, Intl.PluralRules,
 // Intl date/number formatting, live re-render via the `i18n:change` event.
 
-import { emit } from './events.js';
+import { emit, on } from './events.js';
 
 const LOCALE_KEY = 'couplecards:locale';
 const SUPPORTED = new Set(['en', 'fr', 'de', 'it', 'es']);
@@ -132,12 +132,8 @@ function announceLocale(locale) {
 // new locale (after the initial boot) so screen-reader users get feedback when
 // they pick a language.
 let announceArmed = false;
-if (typeof window !== 'undefined') {
-  import('./events.js').then(({ on }) => {
-    on('i18n:change', (locale) => {
-      applyI18n(document);
-      if (announceArmed) announceLocale(locale);
-      announceArmed = true;
-    });
-  });
-}
+on('i18n:change', (locale) => {
+  applyI18n(document);
+  if (announceArmed) announceLocale(locale);
+  announceArmed = true;
+});

--- a/public/js/features/admin/cards.js
+++ b/public/js/features/admin/cards.js
@@ -6,7 +6,7 @@ import { request, errorMessage } from '../../core/api.js';
 import { t, getLocale, supportedLocales } from '../../core/i18n.js';
 import { getCardText } from '../../core/sync.js';
 import { on } from '../../core/events.js';
-import { toast, showConfirm } from '../../ui/shell.js';
+import { toast, showConfirm, withModal } from '../../ui/shell.js';
 import { mountDeckTools } from './deck-sync.js';
 import { escapeHtml } from '../../core/dom.js';
 import { EMOJI_SLUGS } from './emoji-slugs.js';
@@ -114,129 +114,82 @@ function collectTranslations(form) {
 }
 
 function openCardDialog({ card = null } = {}) {
-  const host = document.getElementById('modal');
-  const titleEl = document.getElementById('modal-title');
-  const bodyEl = document.getElementById('modal-body');
-  const confirmBtn = document.getElementById('modal-confirm');
-  const cancelBtn = document.getElementById('modal-cancel');
-  const backdrop = host?.querySelector('[data-modal-close]');
-  if (!host) return;
-
-  const previouslyFocused = document.activeElement;
   const isEdit = !!card;
-  titleEl.textContent = isEdit ? t('admin.cards.edit') : t('admin.cards.create');
-  bodyEl.innerHTML = `
-    <form id="card-form" class="card-form">
-      <label class="field">
-        <span>${escapeHtml(t('admin.cards.id'))}</span>
-        <input type="text" id="card-id" value="${card ? escapeHtml(card.id) : ''}"
-               ${isEdit ? 'readonly' : ''} required
-               pattern="[a-z0-9\\-]{1,64}">
-        <small>${escapeHtml(t('admin.cards.idHint'))}</small>
-      </label>
-      <label class="field">
-        <span>${escapeHtml(t('admin.cards.pile'))}</span>
-        <select id="card-pile" required>
-          <option value="home" ${card?.pile === 'home' ? 'selected' : ''}>${escapeHtml(t('piles.home.label'))}</option>
-          <option value="outdoor" ${card?.pile === 'outdoor' ? 'selected' : ''}>${escapeHtml(t('piles.outdoor.label'))}</option>
-        </select>
-      </label>
-      ${SUPPORTED_LOCALES.map((loc) => renderTranslationSection(loc, card)).join('')}
-      <label class="field-inline">
-        <input type="checkbox" id="card-foil" ${card?.foil ? 'checked' : ''}>
-        <span>${escapeHtml(t('admin.cards.foil'))}</span>
-      </label>
-      <label class="field">
-        <span>${escapeHtml(t('admin.cards.emoji'))}</span>
-        <input type="text" id="card-emoji" list="card-emoji-slugs"
-               value="${card?.emoji ? escapeHtml(card.emoji) : ''}"
-               pattern="[a-z0-9\\-]{1,64}">
-        <small>${escapeHtml(t('admin.cards.emojiHint'))}</small>
-      </label>
-      <datalist id="card-emoji-slugs">
-        ${EMOJI_SLUGS.map((s) => `<option value="${escapeHtml(s)}"></option>`).join('')}
-      </datalist>
-      <div class="cp-error" id="card-error" role="alert"></div>
-    </form>
-  `;
-  confirmBtn.textContent = t('common.save');
-  confirmBtn.classList.add('btn-primary');
-  confirmBtn.classList.remove('btn-danger');
-  confirmBtn.disabled = false;
-  cancelBtn.hidden = false;
-  cancelBtn.textContent = t('common.cancel');
-  host.hidden = false;
-
-  const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-  const getFocusables = () => Array.from(host.querySelectorAll(FOCUSABLE))
-    .filter((el) => !el.hidden && el.offsetParent !== null);
-
-  const close = () => {
-    host.hidden = true;
-    confirmBtn.removeEventListener('click', onConfirm);
-    cancelBtn.removeEventListener('click', onCancel);
-    backdrop?.removeEventListener('click', onCancel);
-    document.removeEventListener('keydown', onKey);
-    if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
-      try { previouslyFocused.focus(); } catch {}
-    }
-  };
-  const onCancel = () => close();
-  const onKey = (event) => {
-    if (event.key === 'Escape') { event.preventDefault(); close(); return; }
-    if (event.key !== 'Tab') return;
-    const items = getFocusables();
-    if (items.length === 0) return;
-    const first = items[0];
-    const last = items[items.length - 1];
-    if (event.shiftKey && document.activeElement === first) {
-      event.preventDefault();
-      last.focus();
-    } else if (!event.shiftKey && document.activeElement === last) {
-      event.preventDefault();
-      first.focus();
-    }
-  };
-  const onConfirm = async () => {
-    const form = document.getElementById('card-form');
-    const err = document.getElementById('card-error');
-    err.textContent = '';
-    const translations = collectTranslations(form);
-    if (Object.keys(translations).length === 0) {
-      err.textContent = t('errors.VALIDATION_ERROR');
-      return;
-    }
-    const emojiValue = document.getElementById('card-emoji').value.trim();
-    const payload = {
-      pile: document.getElementById('card-pile').value,
-      foil: document.getElementById('card-foil').checked,
-      emoji: emojiValue || null,
-      translations,
-    };
-    confirmBtn.disabled = true;
-    try {
-      if (isEdit) {
-        await request(`/api/cards/${encodeURIComponent(card.id)}`, { method: 'PATCH', body: payload });
-      } else {
-        payload.id = document.getElementById('card-id').value.trim();
-        await request('/api/cards', { method: 'POST', body: payload });
+  withModal({
+    title: isEdit ? t('admin.cards.edit') : t('admin.cards.create'),
+    bodyHtml: `
+      <form id="card-form" class="card-form">
+        <label class="field">
+          <span>${escapeHtml(t('admin.cards.id'))}</span>
+          <input type="text" id="card-id" value="${card ? escapeHtml(card.id) : ''}"
+                 ${isEdit ? 'readonly' : ''} required
+                 pattern="[a-z0-9\\-]{1,64}">
+          <small>${escapeHtml(t('admin.cards.idHint'))}</small>
+        </label>
+        <label class="field">
+          <span>${escapeHtml(t('admin.cards.pile'))}</span>
+          <select id="card-pile" required>
+            <option value="home" ${card?.pile === 'home' ? 'selected' : ''}>${escapeHtml(t('piles.home.label'))}</option>
+            <option value="outdoor" ${card?.pile === 'outdoor' ? 'selected' : ''}>${escapeHtml(t('piles.outdoor.label'))}</option>
+          </select>
+        </label>
+        ${SUPPORTED_LOCALES.map((loc) => renderTranslationSection(loc, card)).join('')}
+        <label class="field-inline">
+          <input type="checkbox" id="card-foil" ${card?.foil ? 'checked' : ''}>
+          <span>${escapeHtml(t('admin.cards.foil'))}</span>
+        </label>
+        <label class="field">
+          <span>${escapeHtml(t('admin.cards.emoji'))}</span>
+          <input type="text" id="card-emoji" list="card-emoji-slugs"
+                 value="${card?.emoji ? escapeHtml(card.emoji) : ''}"
+                 pattern="[a-z0-9\\-]{1,64}">
+          <small>${escapeHtml(t('admin.cards.emojiHint'))}</small>
+        </label>
+        <datalist id="card-emoji-slugs">
+          ${EMOJI_SLUGS.map((s) => `<option value="${escapeHtml(s)}"></option>`).join('')}
+        </datalist>
+        <div class="cp-error" id="card-error" role="alert"></div>
+      </form>
+    `,
+    confirmLabel: t('common.save'),
+    cancelLabel: t('common.cancel'),
+    initialFocus: () => (isEdit
+      ? document.querySelector('[name="title-' + getLocale() + '"]')
+      : document.getElementById('card-id')),
+    onConfirm: async ({ close, confirmBtn }) => {
+      const form = document.getElementById('card-form');
+      const err = document.getElementById('card-error');
+      err.textContent = '';
+      const translations = collectTranslations(form);
+      if (Object.keys(translations).length === 0) {
+        err.textContent = t('errors.VALIDATION_ERROR');
+        return;
       }
-      close();
-      toast(t('admin.cards.saved.toast'));
-      await renderCards();
-    } catch (e) {
-      err.textContent = errorMessage(e);
-    } finally {
-      confirmBtn.disabled = false;
-    }
-  };
-  confirmBtn.addEventListener('click', onConfirm);
-  cancelBtn.addEventListener('click', onCancel);
-  backdrop?.addEventListener('click', onCancel);
-  document.addEventListener('keydown', onKey);
-  setTimeout(() => (isEdit
-    ? document.querySelector('[name="title-' + getLocale() + '"]')
-    : document.getElementById('card-id'))?.focus(), 50);
+      const emojiValue = document.getElementById('card-emoji').value.trim();
+      const payload = {
+        pile: document.getElementById('card-pile').value,
+        foil: document.getElementById('card-foil').checked,
+        emoji: emojiValue || null,
+        translations,
+      };
+      confirmBtn.disabled = true;
+      try {
+        if (isEdit) {
+          await request(`/api/cards/${encodeURIComponent(card.id)}`, { method: 'PATCH', body: payload });
+        } else {
+          payload.id = document.getElementById('card-id').value.trim();
+          await request('/api/cards', { method: 'POST', body: payload });
+        }
+        close();
+        toast(t('admin.cards.saved.toast'));
+        await renderCards();
+      } catch (e) {
+        err.textContent = errorMessage(e);
+      } finally {
+        confirmBtn.disabled = false;
+      }
+    },
+  });
 }
 
 export async function renderCards() {
@@ -260,7 +213,9 @@ async function deleteCard(id, title) {
 
 export async function mount() {
   mountDeckTools(() => { renderCards().catch(() => {}); });
-  on('i18n:change', () => { renderCards().catch(() => {}); });
+  // Re-render from the cached list: cards already carry every translation,
+  // so a language switch needs no refetch.
+  on('i18n:change', () => { renderCardsList(filterCards()); });
 
   document.getElementById('admin-cards-search')?.addEventListener('input', (e) => {
     cardsQuery = e.target.value;

--- a/public/js/features/admin/deck-sync.js
+++ b/public/js/features/admin/deck-sync.js
@@ -114,7 +114,7 @@ function openSyncDialog() {
     bodyHtml: renderBody(),
     confirmLabel: t('admin.deckSync.apply'),
     cancelLabel: t('common.cancel'),
-    onBodyReady: ({ close }) => wireBody(close),
+    onBodyReady: () => wireBody(),
     onConfirm: async ({ close, confirmBtn }) => {
       confirmBtn.disabled = true;
       try {
@@ -135,7 +135,7 @@ function openSyncDialog() {
     },
   });
 
-  function wireBody(close) {
+  function wireBody() {
     const confirmBtn = document.getElementById('modal-confirm');
     confirmBtn.disabled = true;
     markApplyDanger(confirmBtn, false);
@@ -176,7 +176,7 @@ function openSyncDialog() {
     function rebuild() {
       document.getElementById('modal-body').innerHTML = renderBody();
       document.getElementById('deck-sync-summary-host').innerHTML = lastPreview ? renderSummary(lastPreview) : '';
-      wireBody(close);
+      wireBody();
     }
   }
 
@@ -203,7 +203,7 @@ function openImportDialog(deck, filename) {
     bodyHtml: renderBody(),
     confirmLabel: t('admin.deckSync.apply'),
     cancelLabel: t('common.cancel'),
-    onBodyReady: ({ close }) => wireBody(close),
+    onBodyReady: () => wireBody(),
     onConfirm: async ({ close, confirmBtn }) => {
       confirmBtn.disabled = true;
       try {
@@ -224,7 +224,7 @@ function openImportDialog(deck, filename) {
     },
   });
 
-  function wireBody(close) {
+  function wireBody() {
     const confirmBtn = document.getElementById('modal-confirm');
     confirmBtn.disabled = true;
     markApplyDanger(confirmBtn, false);
@@ -257,7 +257,7 @@ function openImportDialog(deck, filename) {
     function rebuild() {
       document.getElementById('modal-body').innerHTML = renderBody();
       document.getElementById('deck-sync-summary-host').innerHTML = lastPreview ? renderSummary(lastPreview) : '';
-      wireBody(close);
+      wireBody();
     }
   }
 

--- a/public/js/features/admin/users.js
+++ b/public/js/features/admin/users.js
@@ -57,8 +57,8 @@ function renderUsersList(users) {
     row.innerHTML = `
       <div class="list-item-main">
         <div class="list-item-title">${escapeHtml(u.username)}</div>
-        <div class="list-item-meta">${escapeHtml(t('admin.users.createdAt', { when: fmtDateLong(u.createdAt) }))}</div>
-        <div class="list-item-meta">${escapeHtml(u.lastLoginAt ? t('admin.users.lastLogin', { when: fmtDateLong(u.lastLoginAt) }) : t('admin.users.neverLogged'))}</div>
+        <div class="list-item-meta">${escapeHtml(t('admin.users.createdAt', { when: fmtDateLong(u.createdAt + 'Z') }))}</div>
+        <div class="list-item-meta">${escapeHtml(u.lastLoginAt ? t('admin.users.lastLogin', { when: fmtDateLong(u.lastLoginAt + 'Z') }) : t('admin.users.neverLogged'))}</div>
         <div class="list-item-badges">${badges.join('')}</div>
       </div>
       ${actions ? `<div class="list-item-actions">${actions}</div>` : ''}
@@ -222,7 +222,9 @@ export async function mount() {
     }
   });
 
-  on('i18n:change', () => { renderUsers().catch(() => {}); });
+  // Re-render from the cached list: usernames are locale-independent, only
+  // the labels and date formats change, so no refetch is needed.
+  on('i18n:change', () => { renderUsersList(filterUsers()); });
 
   document.getElementById('admin-users-search')?.addEventListener('input', (e) => {
     usersQuery = e.target.value;

--- a/public/js/features/collection/collection.js
+++ b/public/js/features/collection/collection.js
@@ -46,7 +46,9 @@ function buildCardFront(card, title, description, locale) {
   emojiSpan.appendChild(createEmojiImg(card.emoji || (card.pile === 'home' ? 'house' : 'city'), '', { lazy: true }));
   art.appendChild(emojiSpan);
 
-  const titleEl = document.createElement('h3');
+  // Not a heading: the tile is a role="button", and dozens of headings inside
+  // buttons pollute screen-reader heading navigation.
+  const titleEl = document.createElement('div');
   titleEl.className = 'card-title';
   titleEl.textContent = title;
   titleEl.setAttribute('lang', locale);

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -468,6 +468,11 @@ function detachTilt() {
   }
   tiltPointerMove = tiltPointerDown = tiltPointerUp = tiltPointerLeave = null;
   tiltActive = false;
+  // Kill a return-to-center animation still in flight: a stale rAF would
+  // write to detached nodes, and if the tab was hidden mid-return the paused
+  // animation would keep isReturning stuck and block tilt on the next mount.
+  if (returnRaf) { cancelAnimationFrame(returnRaf); returnRaf = 0; }
+  isReturning = false;
   if (orientationAttached && orientationHandler) {
     window.removeEventListener('deviceorientation', orientationHandler);
     orientationAttached = false;
@@ -822,13 +827,14 @@ function onVisibilityChange() {
     return;
   }
   bumpInactivity();
-  // Resume the ambient effects when the user is back and a card has been
-  // revealed (the settled class means the flip animation has landed).
-  // startHearts/startRipples no-op in preview, so no guard is needed here.
-  const settled = $('card-flip')?.classList.contains('settled');
-  if (settled) {
+  // Resume the hearts when the user is back and a card has been revealed
+  // (the settled class means the flip animation has landed). Ripples stay
+  // off: they only run during the pre-reveal build-up and are stopped for
+  // good once the card settles, so restarting them here would resurrect an
+  // infinite loop that never exists outside a tab switch.
+  // startHearts no-ops in preview, so no guard is needed here.
+  if ($('card-flip')?.classList.contains('settled')) {
     startHearts();
-    startRipples(CONFIG.ripples.normalInterval);
   }
 }
 

--- a/public/js/features/history/history.js
+++ b/public/js/features/history/history.js
@@ -28,7 +28,7 @@ function groupByDate(history) {
     month:     { label: t('history.groups.month'),     items: [] },
     older:     { label: t('history.groups.older'),     items: [] },
   };
-  history.forEach((entry, index) => {
+  history.forEach((entry) => {
     const tm = startOfDay(new Date(entry.drawnAt));
     let bucket;
     if (tm >= today) bucket = buckets.today;
@@ -36,7 +36,7 @@ function groupByDate(history) {
     else if (tm >= weekAgo) bucket = buckets.week;
     else if (tm >= monthAgo) bucket = buckets.month;
     else bucket = buckets.older;
-    bucket.items.push({ entry, index });
+    bucket.items.push(entry);
   });
   return Object.values(buckets).filter((b) => b.items.length > 0);
 }
@@ -61,7 +61,7 @@ function render() {
     header.textContent = group.label;
     host.appendChild(header);
 
-    for (const { entry } of group.items) {
+    for (const entry of group.items) {
       const card = getCardById(entry.cardId);
       const title = card ? getCardText(card).title : t('history.card.deleted');
       const pile = card ? card.pile : null;

--- a/public/js/ui/shell.js
+++ b/public/js/ui/shell.js
@@ -139,7 +139,9 @@ export function showConfirm({
 // to disable Escape and backdrop-click closing (used when accidental
 // dismissal would lose unrecoverable state, e.g. a generated password
 // shown only once).
-export function withModal({ title, bodyHtml, confirmLabel, cancelLabel, danger, onConfirm, onBodyReady, dismissable = true }) {
+// Optional initialFocus: a function returning the element to focus on open,
+// for dialogs whose natural starting field is not the first focusable one.
+export function withModal({ title, bodyHtml, confirmLabel, cancelLabel, danger, onConfirm, onBodyReady, dismissable = true, initialFocus }) {
   const host = document.getElementById('modal');
   const titleEl = document.getElementById('modal-title');
   const bodyEl = document.getElementById('modal-body');
@@ -208,8 +210,9 @@ export function withModal({ title, bodyHtml, confirmLabel, cancelLabel, danger, 
   onBodyReady?.({ close });
 
   setTimeout(() => {
+    const preferred = typeof initialFocus === 'function' ? initialFocus() : null;
     const [first] = getFocusables();
-    (first || confirmBtn).focus();
+    (preferred || first || confirmBtn).focus();
   }, 50);
 
   return { close };

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards: stale-while-revalidate (allows offline viewing)
 //   * all other /api/*: network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v47';
+const VERSION = 'couplecards-v48';
 const SHELL = [
   '/',
   '/index.html',

--- a/server/src/db/seed.js
+++ b/server/src/db/seed.js
@@ -2,17 +2,15 @@
 // First-run seed: default admin, optional demo account, multilingual starter
 // deck from every data/cards.*.json.
 
-import { readFileSync, existsSync, readdirSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { config } from '../config.js';
 import { getDb, transaction, setSetting } from './index.js';
 import { hashPassword, verifyPassword } from '../lib/password.js';
 import { SUPPORTED_LOCALES } from '../lib/locales.js';
+import { readSeedDecks } from '../lib/deckSync.js';
 
 const DEFAULT_ADMIN_PASSWORD = 'changeme';
 const DEMO_USERNAME = 'demo';
 const DEMO_PASSWORD = 'demo';
-const SEED_FILE_PATTERN = /^cards\.([a-z]{2})\.json$/i;
 
 export async function runSeed(logger) {
   const db = getDb();
@@ -70,11 +68,8 @@ export async function runSeed(logger) {
 
   const cardCount = db.prepare('SELECT COUNT(*) AS n FROM cards').get().n;
   if (cardCount === 0) {
-    const deck = loadSeedDeck(logger);
-    if (deck.length === 0) {
-      logger?.warn('no cards.*.json files found under the data directory, skipping card seed');
-      return;
-    }
+    const deck = loadSeedDeckSafe(logger);
+    if (deck.length === 0) return;
     const insertCard = db.prepare(`
       INSERT INTO cards (id, pile, foil, emoji, sort_order)
       VALUES (@id, @pile, @foil, @emoji, @sort_order)
@@ -113,7 +108,7 @@ function backfillCardEmoji(logger) {
   const db = getDb();
   const stillNull = db.prepare('SELECT COUNT(*) AS n FROM cards WHERE emoji IS NULL').get().n;
   if (stillNull === 0) return;
-  const deck = loadSeedDeck(logger);
+  const deck = loadSeedDeckSafe(logger);
   if (deck.length === 0) return;
   const update = db.prepare(`
     UPDATE cards SET emoji = ?, updated_at = datetime('now')
@@ -150,68 +145,20 @@ export async function maybeResetAdmin(logger) {
   logger?.warn('ADMIN_RESET was enabled: admin password reset to "changeme". Unset the variable and restart.');
 }
 
-// Merges every data/cards.<locale>.json into a single deck keyed by card id.
-// A card may ship only one translation; structural fields (pile, foil, emoji)
-// must agree across locales for the same id.
-function loadSeedDeck(logger) {
-  const dir = config.dataSeedDir;
-  if (!existsSync(dir)) return [];
-  const byId = new Map();
-  let firstLocaleOrder = null;
-  for (const file of readdirSync(dir)) {
-    const match = SEED_FILE_PATTERN.exec(file);
-    if (!match) continue;
-    const locale = match[1].toLowerCase();
-    if (!SUPPORTED_LOCALES.includes(locale)) {
-      logger?.warn({ file, locale }, 'skipping seed file for an unsupported locale');
-      continue;
-    }
-    const payload = JSON.parse(readFileSync(resolve(dir, file), 'utf8'));
-    const cards = Array.isArray(payload?.cards) ? payload.cards : [];
-    if (firstLocaleOrder === null) firstLocaleOrder = locale;
-    cards.forEach((raw, index) => {
-      if (!raw || typeof raw.id !== 'string') return;
-      const existing = byId.get(raw.id);
-      if (existing) {
-        if (
-          existing.pile !== raw.pile
-          || !!existing.foil !== !!raw.foil
-          || (existing.emoji ?? null) !== (raw.emoji ?? null)
-        ) {
-          throw new Error(
-            `seed card "${raw.id}": structural fields differ between locales `
-              + `(pile=${existing.pile}/${raw.pile}, foil=${existing.foil}/${!!raw.foil}, `
-              + `emoji=${existing.emoji ?? 'null'}/${raw.emoji ?? 'null'})`,
-          );
-        }
-        existing.translations[locale] = {
-          title: String(raw.title ?? ''),
-          description: String(raw.description ?? ''),
-        };
-      } else {
-        const order = locale === firstLocaleOrder ? index : Number.MAX_SAFE_INTEGER;
-        byId.set(raw.id, {
-          id: raw.id,
-          pile: raw.pile,
-          foil: !!raw.foil,
-          emoji: typeof raw.emoji === 'string' ? raw.emoji : null,
-          sortOrder: order,
-          translations: {
-            [locale]: {
-              title: String(raw.title ?? ''),
-              description: String(raw.description ?? ''),
-            },
-          },
-        });
-      }
-    });
+// Same reader and validation as the admin "sync from files" path, so a card
+// that seeds at first boot can never later fail POST /cards/sync. At boot a
+// missing or malformed data directory degrades to an empty deck (warn and
+// skip) instead of refusing to start.
+function loadSeedDeckSafe(logger) {
+  try {
+    return readSeedDecks();
+  } catch (err) {
+    logger?.warn(
+      { reason: err.deckCode || err.message },
+      'seed deck unavailable or invalid, skipping card seed/backfill',
+    );
+    return [];
   }
-  // Normalize sort order so cards introduced only by a later locale still
-  // get a deterministic position.
-  const deck = [...byId.values()];
-  deck.sort((a, b) => a.sortOrder - b.sortOrder || a.id.localeCompare(b.id));
-  deck.forEach((card, index) => { card.sortOrder = index; });
-  return deck;
 }
 
 function pickSeedLocale() {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -121,11 +121,17 @@ async function start() {
 
   const shutdown = async (signal) => {
     app.log.info({ signal }, 'shutting down');
+    // Safety net: if close() hangs (stuck connection), still exit before the
+    // orchestrator escalates to SIGKILL. unref() keeps the timer from holding
+    // the process open on the normal path.
+    setTimeout(() => process.exit(1), 5000).unref();
     try {
       await app.close();
       closeDb();
-    } finally {
       process.exit(0);
+    } catch (err) {
+      app.log.error(err, 'shutdown failed');
+      process.exit(1);
     }
   };
   process.once('SIGINT', () => shutdown('SIGINT'));

--- a/server/src/plugins/csrf.js
+++ b/server/src/plugins/csrf.js
@@ -9,7 +9,7 @@ import fp from 'fastify-plugin';
 import csrf from '@fastify/csrf-protection';
 
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
-const EXEMPT_PREFIXES = ['/api/auth/login', '/api/auth/register', '/api/auth/csrf'];
+const EXEMPT_PATHS = new Set(['/api/auth/login', '/api/auth/register', '/api/auth/csrf']);
 
 export default fp(async function csrfPlugin(app) {
   await app.register(csrf, {
@@ -20,7 +20,10 @@ export default fp(async function csrfPlugin(app) {
   app.addHook('preHandler', (request, reply, done) => {
     if (!MUTATING_METHODS.has(request.method)) return done();
     if (!request.url.startsWith('/api/')) return done();
-    if (EXEMPT_PREFIXES.some((prefix) => request.url.startsWith(prefix))) return done();
+    // Exact path match (query string stripped): a prefix test would silently
+    // exempt any future route that merely starts with an exempt path.
+    const path = request.url.split('?')[0];
+    if (EXEMPT_PATHS.has(path)) return done();
     app.csrfProtection(request, reply, done);
   });
 });

--- a/server/src/routes/cards.js
+++ b/server/src/routes/cards.js
@@ -2,7 +2,7 @@
 // Cards: read by any authenticated user, CRUD reserved to admin. The deck is
 // multilingual: each card carries a `translations` map keyed by locale.
 
-import { getDb, transaction } from '../db/index.js';
+import { getDb, transaction, isUniqueViolation } from '../db/index.js';
 import { requireSession, requireAdmin, enforcePasswordChange } from '../lib/auth.js';
 import { SUPPORTED_LOCALES } from '../lib/locales.js';
 import { TITLE_MAX, DESCRIPTION_MAX } from '../lib/card-limits.js';
@@ -41,7 +41,18 @@ function selectCards() {
 // version in module scope and invalidate from every mutating handler (and
 // from applyDeckSync) so the 304 response becomes a plain string compare.
 let cachedDeckVersion = null;
-export function invalidateDeckVersion() { cachedDeckVersion = null; }
+
+// Every caller is a post-commit mutation path, so bumping the persistent
+// revision here is safe. The counter disambiguates edits that land within
+// the same second with unchanged row counts, which would otherwise produce
+// an identical ETag and leave clients on a 304 with stale text.
+export function invalidateDeckVersion() {
+  cachedDeckVersion = null;
+  getDb().prepare(`
+    INSERT INTO settings (key, value) VALUES ('deck_revision', '1')
+    ON CONFLICT(key) DO UPDATE SET value = CAST(value AS INTEGER) + 1
+  `).run();
+}
 
 function deckVersion() {
   if (cachedDeckVersion !== null) return cachedDeckVersion;
@@ -52,7 +63,8 @@ function deckVersion() {
     FROM cards
   `).get();
   const trCount = getDb().prepare('SELECT COUNT(*) AS n FROM card_translations').get().n;
-  cachedDeckVersion = `${row.v}-${row.n}-${trCount}`;
+  const rev = getDb().prepare(`SELECT value FROM settings WHERE key = 'deck_revision'`).get()?.value ?? '0';
+  cachedDeckVersion = `${row.v}-${row.n}-${trCount}-${rev}`;
   return cachedDeckVersion;
 }
 
@@ -122,7 +134,9 @@ export default async function cardRoutes(app) {
         writeTranslations(db, id, translations);
       })();
     } catch (err) {
-      if (err.code === 'SQLITE_CONSTRAINT_PRIMARYKEY') {
+      // node:sqlite reports the duplicate TEXT primary key as a UNIQUE
+      // violation (never as a 'SQLITE_CONSTRAINT_PRIMARYKEY' code string).
+      if (isUniqueViolation(err)) {
         return reply.code(409).send({ error: 'CARD_ID_EXISTS' });
       }
       throw err;

--- a/server/src/routes/health.js
+++ b/server/src/routes/health.js
@@ -2,7 +2,6 @@
 // Liveness probe. No auth. Safe to expose externally.
 
 import { getDb } from '../db/index.js';
-import { config } from '../config.js';
 
 export default async function healthRoutes(app) {
   app.get('/health', {
@@ -13,7 +12,6 @@ export default async function healthRoutes(app) {
           type: 'object',
           properties: {
             status: { type: 'string' },
-            version: { type: 'string' },
             dbOk: { type: 'boolean' },
           },
         },
@@ -27,6 +25,8 @@ export default async function healthRoutes(app) {
     } catch {
       dbOk = false;
     }
-    return { status: 'ok', version: config.version, dbOk };
+    // No version here on purpose: the endpoint is public and the exact app
+    // version is free reconnaissance on internet-exposed deployments.
+    return { status: 'ok', dbOk };
   });
 }


### PR DESCRIPTION
Second review pass over the areas the first one only skimmed: the draw module, the admin features, CSS/accessibility, the seed/deck-sync layer, and the deployment files. Two real bugs, a batch of robustness and accessibility fixes, and dead-code removal.

## Security and correctness

- The bundled nginx configuration used `proxy_hide_header` on Content-Security-Policy and Permissions-Policy, which strips the app's own headers: the nginx variant served the entire app without CSP. Lines removed; Caddy and Traefik variants were already correct.
- Creating a card with an existing id returned 500 instead of 409: the code compared against the `SQLITE_CONSTRAINT_PRIMARYKEY` string that `node:sqlite` never emits. Now uses the shared `isUniqueViolation()` helper.
- CSRF exemptions match the exact path (query string stripped) instead of a prefix.
- `/api/health` no longer exposes the app version (nothing consumed it).
- Graceful shutdown exits 1 when close fails and has a 5-second fallback.

## Behavior and accessibility

- Admin Users tab: creation and last-login times were displayed shifted by the viewer's UTC offset.
- `ENABLE_REGISTRATION` from `.env` now reaches the container; HTTPS deploy variants also pass `ADMIN_RESET` and `ENABLE_DEMO_ACCOUNT`.
- Reduced motion now also disables the full-screen reveal flash, the revealed card's infinite shine sweep (orphaned selector after a rename), and the screen slide-in.
- Tab switch no longer resurrects the draw screen's ripple loop on a settled card; a stale return-to-center animation can no longer freeze the card tilt on the next draw.
- Two deck edits within the same second now produce distinct ETags (persistent revision counter), so clients cannot get stuck on stale card text.
- Collection tiles no longer place headings inside `role="button"` elements.

## Maintenance

- `seed.js` reuses the deck-sync reader (60 duplicated lines removed); seed files are now validated at boot with the same rules as the admin sync, so a deck that seeds can never later fail the sync.
- The admin card dialog is rebuilt on the shared `withModal()` helper (70 duplicated focus-trap lines removed; `withModal` gains an `initialFocus` option).
- Docker image roughly halves: ownership is set with `COPY --chown` instead of a duplicating `chown -R` layer; the healthcheck follows `PORT`.
- Admin language switches re-render from cache instead of refetching both lists.
- Dead code removed: unused parameters, an unnecessary dynamic import, a CSS rule targeting a nonexistent animation, and the broken `add-spdx` npm script (CONTRIBUTING updated).

## Expected behaviors after merge

- nginx deployments serve the app with its CSP intact.
- Duplicate card ids show the "identifier already in use" message in the admin UI.
- Admin user dates match the viewer's local time.
- Users with "reduce motion" get no white flash and no looping shine on reveal.

Verified locally: syntax checks on all touched files, and 12 API tests against a live dev server (health payload, forced admin password change, seeding through the shared reader, duplicate-id 409, same-second ETag changes, CSRF exact-path behavior) all pass. The Docker image size claim follows from how layers work; CI builds the image as its check.
