### PR TITLE
feat: gold-dust card reveal animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- The card reveal was redesigned around a "gold dust" sequence. The card now levitates while golden particles swirl into it, takes a sharp breath, then flips with a light sweep across its face; the landing sends out a golden shockwave (the full-screen white flash is gone), embers rain down, the card text cascades in, and the revealed card keeps floating gently over its shadow surrounded by a thin ambient dust. The floating emoji hearts are retired in favor of that ambient dust, and particle density adapts to the device so low-end phones get the same choreography with fewer particles.
 - The Docker image is roughly half as large: file ownership is set during copy instead of in a duplicating chown layer.
 - `/api/health` no longer exposes the app version publicly; it only reports liveness.
 - Seed files are validated at first boot with the same rules as the admin "sync from files" operation; malformed files are skipped with a warning instead of seeding unvalidated data.

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -112,46 +112,76 @@
   opacity: 0;
 }
 
-.card-flip.enter { animation: card-enter 0.55s cubic-bezier(0.2, 1.4, 0.3, 1) forwards; }
+.card-flip.enter { animation: card-enter 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
 @keyframes card-enter {
-  0%   { opacity: 0; transform: rotateY(0deg) scale(0.35) translateY(60px); }
-  60%  { opacity: 1; transform: rotateY(0deg) scale(1.08); }
-  100% { opacity: 1; transform: rotateY(0deg) scale(1); }
+  0%   { opacity: 0; transform: rotateY(0deg) scale(0.82) translateY(46px); }
+  100% { opacity: 1; transform: rotateY(0deg) scale(1) translateY(0); }
 }
 
-.card-flip.pulsing { animation: card-pulse 1.4s cubic-bezier(0.4, 0, 0.2, 1) forwards; }
-@keyframes card-pulse {
-  0%   { transform: rotateY(0deg) scale(1); }
-  18%  { transform: rotateY(0deg) scale(1.06) rotate(-1.5deg); }
-  30%  { transform: rotateY(0deg) scale(0.98) rotate(1deg); }
-  48%  { transform: rotateY(0deg) scale(1.1)  rotate(-2deg); }
-  62%  { transform: rotateY(0deg) scale(0.97) rotate(1.5deg); }
-  78%  { transform: rotateY(0deg) scale(1.15) rotate(-2.5deg); }
-  90%  { transform: rotateY(0deg) scale(1.08) rotate(1deg); }
-  100% { transform: rotateY(0deg) scale(1.18); }
+/* Charge: the card slowly levitates while the gold dust swirls into it. */
+.card-flip.charging { animation: card-charge 1.9s cubic-bezier(0.4, 0, 0.3, 1) forwards; }
+@keyframes card-charge {
+  0%   { transform: rotateY(0deg) scale(1) translateY(0); }
+  55%  { transform: rotateY(0deg) scale(1.03) translateY(-14px); }
+  100% { transform: rotateY(0deg) scale(1.06) translateY(-18px); }
 }
 
-.card-flip.climax {
-  animation: card-climax 0.45s cubic-bezier(0.3, 0, 0.2, 1) forwards;
-}
-@keyframes card-climax {
-  0%   { transform: rotateY(0deg) scale(1.18); }
-  40%  { transform: rotateY(0deg) scale(1.25) translate(3px, -2px); }
-  60%  { transform: rotateY(0deg) scale(1.25) translate(-4px, 2px); }
-  80%  { transform: rotateY(0deg) scale(1.25) translate(2px, -1px); }
-  100% { transform: rotateY(0deg) scale(1.28); }
+/* Inhale: one sharp contraction, then the release into the flip. */
+.card-flip.climax { animation: card-inhale 0.5s cubic-bezier(0.6, 0, 0.3, 1) forwards; }
+@keyframes card-inhale {
+  0%   { transform: rotateY(0deg) scale(1.06) translateY(-18px); }
+  55%  { transform: rotateY(0deg) scale(0.965) translateY(-14px); }
+  100% { transform: rotateY(0deg) scale(1.09) translateY(-20px); }
 }
 
-.card-flip.flipping { animation: card-flip-anim 0.75s cubic-bezier(0.5, 0, 0.3, 1) forwards; }
+.card-flip.flipping { animation: card-flip-anim 0.7s cubic-bezier(0.7, 0, 0.25, 1) forwards; }
 @keyframes card-flip-anim {
-  0%   { transform: rotateY(0deg)   scale(1.28); }
-  50%  { transform: rotateY(90deg)  scale(1.32); }
-  100% { transform: rotateY(180deg) scale(1); }
+  0%   { transform: rotateY(0deg)   scale(1.09) translateY(-20px); }
+  50%  { transform: rotateY(92deg)  scale(1.12) translateY(-30px); }
+  100% { transform: rotateY(180deg) scale(1) translateY(0); }
 }
 .card-flip.settled {
-  animation: none !important;
+  animation: none;
   transform: rotateY(180deg) scale(1);
   opacity: 1;
+}
+/* Gentle levitation once revealed; the ground shadow breathes in sync. */
+.card-flip.settled.floaty { animation: card-float 4.5s ease-in-out 0.6s infinite; }
+@keyframes card-float {
+  0%, 100% { transform: rotateY(180deg) scale(1) translateY(0); }
+  50%      { transform: rotateY(180deg) scale(1) translateY(-7px); }
+}
+
+/* Edge light that builds along the card back during the charge. */
+.card-back::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  box-shadow:
+    inset 0 0 24px rgba(255, 220, 160, 0.55),
+    inset 0 0 4px rgba(255, 240, 200, 0.9);
+  transition: opacity 1.6s ease-in;
+}
+.card-flip.charging .card-back::after,
+.card-flip.climax .card-back::after { opacity: 1; }
+
+/* Text cascade after the reveal (live draws only; preview shows instantly). */
+.card-flip.reveal-cascade .card-pile-label,
+.card-flip.reveal-cascade .card-title,
+.card-flip.reveal-cascade .card-divider,
+.card-flip.reveal-cascade .card-description,
+.card-flip.reveal-cascade .card-footer-mark { opacity: 0; }
+.card-flip.reveal-cascade.settled .card-pile-label  { animation: card-text-in 0.5s 0.15s ease-out forwards; }
+.card-flip.reveal-cascade.settled .card-title       { animation: card-text-in 0.55s 0.3s cubic-bezier(0.2, 0.9, 0.2, 1) forwards; }
+.card-flip.reveal-cascade.settled .card-divider     { animation: card-text-in 0.5s 0.48s ease-out forwards; }
+.card-flip.reveal-cascade.settled .card-description { animation: card-text-in 0.6s 0.62s ease-out forwards; }
+.card-flip.reveal-cascade.settled .card-footer-mark { animation: card-text-in 0.5s 0.75s ease-out forwards; }
+@keyframes card-text-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: none; }
 }
 
 .card-face {
@@ -684,68 +714,83 @@
   opacity: 1;
   animation: bg-breathe 1.6s ease-in-out infinite;
 }
-.bg-glow.boost { animation: bg-breathe 0.55s ease-in-out infinite; }
 @keyframes bg-breathe {
   0%, 100% { transform: translate(-50%, -50%) scale(0.8); }
   50%      { transform: translate(-50%, -50%) scale(1.05); }
 }
 
-/* Concentric energy ripples emanating from the card */
-.ripples {
+/* Shared full-stage layer for spawned effect nodes (dust, ambient, landing).
+   Oversized so motes can start well outside the card. */
+.fx-layer {
   position: absolute;
-  inset: 0;
+  inset: -80px;
   pointer-events: none;
   z-index: 0;
 }
-.ripple {
+.fx-layer.fx-above { z-index: 60; }
+
+/* Gold dust converging into the card during the charge. The midpoint vars
+   (--xm/--ym) bend each path so the dust swirls in instead of flying
+   straight; depth is faked with size, blur, and opacity. */
+.mote {
   position: absolute;
   left: 50%;
   top: 50%;
-  width: 240px;
-  height: 340px;
-  border-radius: 24px;
-  transform: translate(-50%, -50%) scale(0.3);
-  border: 2px solid rgba(255, 215, 140, 0.8);
+  width: var(--s, 4px);
+  height: var(--s, 4px);
+  border-radius: 50%;
+  background: var(--c, #ffe2ad);
+  box-shadow: 0 0 8px var(--c, #ffe2ad);
   opacity: 0;
-  animation: ripple-out 1.3s cubic-bezier(0.2, 0.6, 0.3, 1) forwards;
+  filter: blur(var(--b, 0px));
+  animation: mote-in var(--t, 1.4s) cubic-bezier(0.55, 0, 0.75, 0.4) var(--d, 0s) forwards;
 }
-.ripple.variant-a { border-color: rgba(255, 180, 210, 0.75); }
-.ripple.variant-b { border-color: rgba(180, 200, 255, 0.75); }
-@keyframes ripple-out {
-  0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.25); }
-  15%  { opacity: 1; }
-  100% { opacity: 0; transform: translate(-50%, -50%) scale(2.6); }
+@keyframes mote-in {
+  0%   { opacity: 0; transform: translate(var(--x0), var(--y0)) scale(0.4); }
+  20%  { opacity: var(--o, 0.9); }
+  60%  { opacity: var(--o, 0.9); transform: translate(var(--xm), var(--ym)) scale(0.85); }
+  100% { opacity: 0; transform: translate(-50%, -55%) scale(1.05); }
 }
 
-/* Burst: shard explosion at reveal */
-.burst {
+/* Landing ring: expanding card-shaped shockwave, replaces the old white flash. */
+.shockwave {
   position: absolute;
   left: 50%;
   top: 50%;
-  width: 0;
-  height: 0;
-  pointer-events: none;
-  z-index: 60;
-}
-.burst .shard {
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 3px;
-  height: 80px;
-  transform-origin: 50% 0;
-  background: linear-gradient(180deg, rgba(255, 240, 200, 1), rgba(255, 215, 140, 0.6), transparent);
-  border-radius: 3px;
-  filter: drop-shadow(0 0 6px rgba(255, 220, 150, 0.9));
+  width: min(348px, 84vw);
+  height: min(508px, 74vh);
+  border-radius: 26px;
+  transform: translate(-50%, -50%) scale(1);
   opacity: 0;
+  border: 2px solid var(--c, rgba(255, 220, 160, 0.9));
+  box-shadow:
+    0 0 30px var(--c, rgba(255, 220, 160, 0.5)),
+    inset 0 0 20px var(--c, rgba(255, 220, 160, 0.3));
+  filter: blur(0.5px);
+  animation: shockwave 0.9s cubic-bezier(0.1, 0.7, 0.2, 1) forwards;
 }
-.burst.active .shard {
-  animation: shard-burst 0.9s cubic-bezier(0.2, 0.7, 0.3, 1) forwards;
+@keyframes shockwave {
+  0%   { opacity: 0.95; transform: translate(-50%, -50%) scale(1); }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(1.55); }
 }
-@keyframes shard-burst {
-  0%   { opacity: 0; transform: rotate(var(--a)) translateY(0) scaleY(0.2); }
-  15%  { opacity: 1; }
-  100% { opacity: 0; transform: rotate(var(--a)) translateY(var(--d)) scaleY(1); }
+
+/* Golden fallout raining below the card after the reveal. */
+.ember {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: var(--s, 4px);
+  height: var(--s, 4px);
+  border-radius: 50%;
+  background: var(--c, #ffdf9e);
+  box-shadow: 0 0 10px var(--c, #ffdf9e);
+  opacity: 0;
+  animation: ember var(--t, 2.4s) cubic-bezier(0.2, 0.5, 0.5, 1) var(--d, 0s) forwards;
+}
+@keyframes ember {
+  0%   { opacity: 0; transform: translate(var(--x0), var(--y0)) scale(1); }
+  12%  { opacity: 1; }
+  100% { opacity: 0; transform: translate(calc(var(--x0) + var(--dx)), calc(var(--y0) + var(--dy))) scale(0.5); }
 }
 
 /* Glowing halo pulsing like a heartbeat */
@@ -774,83 +819,72 @@
   100% { opacity: 0.55; transform: scale(0.92); }  /* repos */
 }
 
-/* Small hearts floating around the card */
-.hearts {
+/* Thin ambient dust drifting up around the settled card. */
+.drift {
   position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-}
-.heart {
-  position: absolute;
-  font-size: 2rem;
   left: 50%;
   top: 50%;
-  opacity: 0;
-  animation: heart-float 3.4s cubic-bezier(0.3, 0, 0.5, 1) forwards;
-}
-@media (prefers-reduced-motion: no-preference) and (min-width: 900px) {
-  .heart { filter: drop-shadow(0 0 6px rgba(255, 120, 160, 0.55)); }
-}
-@keyframes heart-float {
-  0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.3) rotate(var(--r, 0deg)); }
-  15%  { opacity: 1; transform: translate(calc(-50% + var(--dx1) * 0.3), calc(-50% + var(--dy1) * 0.3)) scale(1) rotate(var(--r, 0deg)); }
-  60%  { opacity: 0.85; }
-  100% { opacity: 0; transform: translate(calc(-50% + var(--dx1)), calc(-50% + var(--dy1))) scale(0.7) rotate(calc(var(--r, 0deg) + 20deg)); }
-}
-
-/* Final flash */
-#screen-draw.flash::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(circle at center, rgba(255, 255, 255, 1) 0%, rgba(255, 230, 170, 0.8) 25%, transparent 70%);
-  opacity: 0;
-  animation: flash 0.7s ease-out;
-  pointer-events: none;
-  z-index: 50;
-}
-@keyframes flash {
-  0%   { opacity: 0; transform: scale(0.4); }
-  10%  { opacity: 1; transform: scale(1); }
-  100% { opacity: 0; transform: scale(1.3); }
-}
-
-/* Small anticipatory flash at the climax */
-#screen-draw.preflash::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at center, rgba(255, 215, 140, 0.5), transparent 60%);
-  opacity: 0;
-  animation: preflash 0.45s ease-out;
-  pointer-events: none;
-  z-index: 49;
-}
-@keyframes preflash {
-  0%   { opacity: 0; }
-  50%  { opacity: 1; }
-  100% { opacity: 0; }
-}
-
-/* Particles */
-.particles { position: absolute; inset: 0; pointer-events: none; }
-.particle {
-  position: absolute;
-  width: 8px;
-  height: 8px;
+  width: var(--s, 3px);
+  height: var(--s, 3px);
   border-radius: 50%;
-  left: 50%;
-  top: 50%;
+  background: var(--c, #ffe2ad);
+  box-shadow: 0 0 6px var(--c, #ffe2ad);
   opacity: 0;
-  box-shadow: 0 0 12px currentColor;
+  filter: blur(var(--b, 0px));
+  animation: drift var(--t, 5s) linear var(--d, 0s) forwards;
 }
-.particles.active .particle { animation: particle-fly 1.4s ease-out infinite; }
-@keyframes particle-fly {
-  0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.2); }
-  15%  { opacity: 1; }
-  100% { opacity: 0; transform: translate(var(--tx), var(--ty)) scale(1.2); }
+@keyframes drift {
+  0%   { opacity: 0; transform: translate(var(--x0), var(--y0)) scale(1); }
+  15%  { opacity: var(--o, 0.55); }
+  85%  { opacity: var(--o, 0.55); }
+  100% { opacity: 0; transform: translate(calc(var(--x0) + var(--dx)), calc(var(--y0) + var(--dy))) scale(0.7); }
+}
+
+/* Soft ground shadow under the floating card. */
+.card-ground {
+  position: absolute;
+  left: 50%;
+  bottom: -6%;
+  width: 68%;
+  height: 22px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(0, 0, 0, 0.55), transparent 70%);
+  transform: translateX(-50%);
+  opacity: 0;
+  transition: opacity 0.6s;
+  z-index: 1;
+  pointer-events: none;
+}
+.card-ground.active {
+  opacity: 1;
+  animation: ground-breathe 4.5s ease-in-out 0.6s infinite;
+}
+@keyframes ground-breathe {
+  0%, 100% { transform: translateX(-50%) scaleX(1); opacity: 1; }
+  50%      { transform: translateX(-50%) scaleX(0.86); opacity: 0.7; }
+}
+
+/* Light streak sweeping across the front face as the card turns over. */
+.reveal-streak {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  border-radius: inherit;
+  pointer-events: none;
+}
+.reveal-streak::before {
+  content: "";
+  position: absolute;
+  top: -20%;
+  bottom: -20%;
+  left: -60%;
+  width: 45%;
+  background: linear-gradient(105deg, transparent, rgba(255, 255, 255, 0.28) 45%, rgba(255, 220, 160, 0.5) 50%, rgba(255, 255, 255, 0.28) 55%, transparent);
+  transform: skewX(-12deg);
+}
+.reveal-streak.go::before { animation: streak-sweep 0.65s cubic-bezier(0.4, 0, 0.2, 1) forwards; }
+@keyframes streak-sweep {
+  to { left: 130%; }
 }
 
 /* Draw actions */
@@ -940,15 +974,20 @@
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .card-flip.enter { animation: card-enter-rm 0.3s ease forwards; }
-  .card-flip.pulsing,
+  .card-flip.charging,
   .card-flip.climax { animation: none; }
   .card-flip.flipping { animation: card-flip-rm 0.4s ease forwards; }
-  .particles.active .particle { animation: none; opacity: 0; }
+  .card-flip.settled.floaty { animation: none; }
+  .card-flip.reveal-cascade .card-pile-label,
+  .card-flip.reveal-cascade .card-title,
+  .card-flip.reveal-cascade .card-divider,
+  .card-flip.reveal-cascade .card-description,
+  .card-flip.reveal-cascade .card-footer-mark { opacity: 1; animation: none; }
   .bg-glow.active { animation: none; opacity: 0.4; }
-  .ripple { animation: none; opacity: 0; }
-  .burst.active .shard { animation: none; opacity: 0; }
-  #screen-draw.preflash::before { animation: none; }
-  #screen-draw.flash::after { animation: none; }
+  .mote, .ember, .drift, .shockwave { animation: none; opacity: 0; }
+  .card-ground.active { animation: none; opacity: 0; }
+  .reveal-streak.go::before { animation: none; }
+  .card-back::after { transition: none; opacity: 0; }
   .card-flip.glow-home::after,
   .card-flip.glow-outdoor::after { animation: none; }
   .card-front.idle-shine::before { animation: none; opacity: 0; }

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -3,18 +3,16 @@
 
 export const CONFIG = {
   draw: {
-    enterDuration: 600,
-    pulsingDuration: 1400,
-    climaxDuration: 450,
-    flipDuration: 750,
+    enterDuration: 700,
+    chargeDuration: 1900,
+    climaxDuration: 500,
+    flipDuration: 700,
     revealDelay: 900,
     reducedMotionShort: 150,
   },
   recentExclude: { home: 3, outdoor: 5 },
   tilt: { maxDegrees: 14, orientationClampDeg: 22 },
   swipe: { minDistance: 90, maxDuration: 700, horizontalRatio: 1.5, exitDuration: 360 },
-  hearts: { interval: 1100, doubleBeatChance: 0.3, lifetime: 3200 },
-  ripples: { normalInterval: 460, boostInterval: 180 },
   pileLaunchDuration: 380,
   vibrations: {
     pileTap: 20,

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -3,7 +3,7 @@
 // swipe-to-return.
 
 import { getCardById, getCardText, drawRandom, getHistory, banCard, unbanCard, addHistory, removeHistoryByUuid, isBanned } from '../../core/sync.js';
-import { emojiImgHTML, createEmojiImg, HEART_KEYS } from '../../ui/emoji.js';
+import { emojiImgHTML, createEmojiImg } from '../../ui/emoji.js';
 import { t } from '../../core/i18n.js';
 import { on } from '../../core/events.js';
 import { CONFIG } from '../../config.js';
@@ -17,144 +17,156 @@ let previewMode = false;
 let previewCardId = null;
 // Bumped on each startDraw and on unmount, so an in-flight reveal animation can
 // detect that the user has left and stop before its tail (sound, vibration,
-// hearts) fires on a screen that's already gone.
+// ambient dust) fires on a screen that's already gone.
 let drawGeneration = 0;
 
 const $ = (id) => document.getElementById(id);
 
 // Cached once at module load and refreshed via the MQL change event. Avoids
 // hundreds of matchMedia() calls per second when the tilt rAF loop and the
-// hearts / ripples ticks each ask whether reduced motion is on.
+// dust spawner ticks each ask whether reduced motion is on.
 const reducedMotionMQL = window.matchMedia('(prefers-reduced-motion: reduce)');
 let reducedMotion = reducedMotionMQL.matches;
 reducedMotionMQL.addEventListener('change', (e) => { reducedMotion = e.matches; });
 function prefersReducedMotion() { return reducedMotion; }
 
-function createParticles(color) {
-  const host = $('particles');
-  if (!host) return;
-  host.innerHTML = '';
-  const count = prefersReducedMotion() ? 0 : 8;
-  for (let i = 0; i < count; i++) {
-    const p = document.createElement('div');
-    p.className = 'particle';
-    const angle = (Math.PI * 2 * i) / count + Math.random() * 0.3;
-    const dist = 150 + Math.random() * 90;
-    p.style.setProperty('--tx', `${Math.cos(angle) * dist}px`);
-    p.style.setProperty('--ty', `${Math.sin(angle) * dist}px`);
-    p.style.animationDelay = `${Math.random() * 0.8}s`;
-    p.style.color = color;
-    p.style.background = color;
-    host.appendChild(p);
-  }
+// "Gold dust" reveal: motes converge into the card during the charge, a
+// shockwave + ember fallout replace the old white flash at landing, and a
+// thin ambient dust keeps drifting up while the revealed card floats.
+const DUST_COLORS = ['#ffe2ad', '#ffd3e4', '#fff3d6', '#ffcf8f', '#f7e6ff'];
+// Halve the particle counts on low-core phones; the choreography reads the
+// same, only the density changes.
+const DUST_DENSITY = (navigator.hardwareConcurrency || 8) <= 4 ? 0.5 : 1;
+
+function dustColor() {
+  return DUST_COLORS[Math.floor(Math.random() * DUST_COLORS.length)];
 }
 
-let heartsInterval = null;
-function spawnHeart() {
-  const host = $('hearts');
-  if (!host) return;
-  const h = document.createElement('div');
-  h.className = 'heart';
-  const img = createEmojiImg(HEART_KEYS[Math.floor(Math.random() * HEART_KEYS.length)]);
-  h.appendChild(img);
-  const startX = (Math.random() - 0.5) * 240;
-  const startY = 250 + Math.random() * 50;
-  h.style.left = `calc(50% + ${startX}px)`;
-  h.style.top = `calc(50% + ${startY}px)`;
-  const dx = (Math.random() - 0.5) * 120;
-  const dy = -520 - Math.random() * 180;
-  h.style.setProperty('--dx1', `${dx}px`);
-  h.style.setProperty('--dy1', `${dy}px`);
-  h.style.setProperty('--r', `${(Math.random() - 0.5) * 30}deg`);
-  h.style.fontSize = `${1.8 + Math.random() * 1.2}rem`;
-  host.appendChild(h);
-  setTimeout(() => h.remove(), CONFIG.hearts.lifetime);
+function spawnFx(host, className, vars, lifetime) {
+  const el = document.createElement('div');
+  el.className = className;
+  for (const [k, v] of Object.entries(vars)) el.style.setProperty(k, v);
+  host.appendChild(el);
+  setTimeout(() => el.remove(), lifetime);
 }
-function startHearts() {
+
+function spawnMote(host, swirl) {
+  const ang = Math.random() * Math.PI * 2;
+  const dist = 220 + Math.random() * 300;
+  // Midpoint pushed sideways so the dust arcs into the card in one shared
+  // swirl direction instead of flying in straight lines.
+  const midAng = ang + swirl * (0.5 + Math.random() * 0.4);
+  const midDist = dist * (0.4 + Math.random() * 0.15);
+  const depth = Math.random(); // 0 = near (big, sharp), 1 = far (small, blurred)
+  spawnFx(host, 'mote', {
+    '--x0': `calc(-50% + ${Math.cos(ang) * dist}px)`,
+    '--y0': `calc(-55% + ${Math.sin(ang) * dist * 0.8}px)`,
+    '--xm': `calc(-50% + ${Math.cos(midAng) * midDist}px)`,
+    '--ym': `calc(-55% + ${Math.sin(midAng) * midDist * 0.8}px)`,
+    '--s': `${(5.5 - depth * 3.5).toFixed(1)}px`,
+    '--b': `${(depth * 1.8).toFixed(1)}px`,
+    '--t': `${(0.85 + Math.random() * 0.65).toFixed(2)}s`,
+    '--d': `${(Math.random() * 0.15).toFixed(2)}s`,
+    '--o': (0.55 + Math.random() * 0.45 - depth * 0.25).toFixed(2),
+    '--c': dustColor(),
+  }, 2200);
+}
+
+let dustInterval = null;
+function startDust() {
   // Preview is a static viewer with no ambient effects. Gating here, not just
   // at call sites, keeps that rule in one place for every caller.
-  if (previewMode || heartsInterval || prefersReducedMotion()) return;
-  const tick = () => {
-    spawnHeart();
-    if (Math.random() < CONFIG.hearts.doubleBeatChance) setTimeout(spawnHeart, 120);
-  };
-  tick();
-  heartsInterval = setInterval(tick, CONFIG.hearts.interval);
+  if (previewMode || dustInterval || prefersReducedMotion()) return;
+  const host = $('dust');
+  if (!host) return;
+  const swirl = Math.random() < 0.5 ? 1 : -1;
+  for (let i = 0; i < Math.round(70 * DUST_DENSITY); i++) spawnMote(host, swirl);
+  // Continuous inflow after the opening burst, so the swirl densifies as the
+  // tension rises instead of thinning out.
+  const perTick = Math.max(1, Math.round(2 * DUST_DENSITY));
+  dustInterval = setInterval(() => {
+    for (let i = 0; i < perTick; i++) spawnMote(host, swirl);
+  }, 55);
 }
-function stopHearts() {
-  if (heartsInterval) { clearInterval(heartsInterval); heartsInterval = null; }
+function stopDust() {
+  if (dustInterval) { clearInterval(dustInterval); dustInterval = null; }
 }
 
-let rippleInterval = null;
-const RIPPLE_VARIANTS = ['', 'variant-a', 'variant-b'];
-let rippleVariantIdx = 0;
-function spawnRipple() {
-  const host = $('ripples');
-  if (!host) return;
-  const r = document.createElement('div');
-  const variant = RIPPLE_VARIANTS[rippleVariantIdx++ % RIPPLE_VARIANTS.length];
-  r.className = 'ripple' + (variant ? ' ' + variant : '');
-  host.appendChild(r);
-  setTimeout(() => r.remove(), 1500);
-}
-function startRipples(interval) {
-  if (previewMode) return; // static preview viewer: no ambient ripples (see startHearts)
-  stopRipples();
-  if (prefersReducedMotion()) return;
-  spawnRipple();
-  rippleInterval = setInterval(spawnRipple, interval);
-}
-function stopRipples() {
-  if (rippleInterval) { clearInterval(rippleInterval); rippleInterval = null; }
-}
-
-function createBurst(color) {
-  const host = $('burst');
-  if (!host) return;
-  host.innerHTML = '';
-  host.classList.remove('active');
-  if (prefersReducedMotion()) return;
-  const count = 10;
-  for (let i = 0; i < count; i++) {
-    const shard = document.createElement('div');
-    shard.className = 'shard';
-    const angle = (360 * i) / count + (Math.random() * 12 - 6);
-    const dist = 180 + Math.random() * 120;
-    shard.style.setProperty('--a', `${angle}deg`);
-    shard.style.setProperty('--d', `${dist}px`);
-    shard.style.height = `${60 + Math.random() * 60}px`;
-    if (Math.random() < 0.3) shard.style.background = `linear-gradient(180deg, ${color}, transparent)`;
-    host.appendChild(shard);
+// Landing: two expanding rings (pile-tinted, then rose) and a dense golden
+// fallout raining below the card.
+function spawnLanding(glowColor) {
+  const host = $('landing');
+  if (!host || prefersReducedMotion()) return;
+  spawnFx(host, 'shockwave', { '--c': glowColor }, 1000);
+  setTimeout(() => {
+    spawnFx(host, 'shockwave', { '--c': 'rgba(255, 180, 210, 0.5)' }, 1000);
+  }, 120);
+  for (let i = 0; i < Math.round(70 * DUST_DENSITY); i++) {
+    const depth = Math.random();
+    spawnFx(host, 'ember', {
+      '--x0': `calc(-50% + ${(Math.random() * 260 - 130).toFixed(0)}px)`,
+      '--y0': `calc(-50% + ${(Math.random() * 340 - 180).toFixed(0)}px)`,
+      '--dx': `${(Math.random() * 180 - 90).toFixed(0)}px`,
+      '--dy': `${(100 + Math.random() * 160).toFixed(0)}px`,
+      '--s': `${(5 - depth * 3).toFixed(1)}px`,
+      '--t': `${(1.8 + Math.random() * 1.6).toFixed(2)}s`,
+      '--d': `${(Math.random() * 0.5).toFixed(2)}s`,
+      '--c': dustColor(),
+    }, 4200);
   }
+}
+
+let ambientInterval = null;
+function startAmbient() {
+  if (previewMode || ambientInterval || prefersReducedMotion()) return;
+  const host = $('ambient');
+  if (!host) return;
+  ambientInterval = setInterval(() => {
+    for (let i = 0; i < 2; i++) {
+      const depth = Math.random();
+      spawnFx(host, 'drift', {
+        '--x0': `calc(-50% + ${(Math.random() * 400 - 200).toFixed(0)}px)`,
+        '--y0': `calc(-50% + ${(60 + Math.random() * 160).toFixed(0)}px)`,
+        '--dx': `${(Math.random() * 60 - 30).toFixed(0)}px`,
+        '--dy': `${-(80 + Math.random() * 80).toFixed(0)}px`,
+        '--s': `${(3.5 - depth * 2).toFixed(1)}px`,
+        '--b': `${(depth * 1.5).toFixed(1)}px`,
+        '--t': `${(4 + Math.random() * 2.5).toFixed(2)}s`,
+        '--o': (0.55 - depth * 0.3).toFixed(2),
+        '--c': dustColor(),
+      }, 7000);
+    }
+  }, 700);
+}
+function stopAmbient() {
+  if (ambientInterval) { clearInterval(ambientInterval); ambientInterval = null; }
 }
 
 function wait(ms) { return new Promise((r) => setTimeout(r, ms)); }
 
 function resetStage() {
-  stopHearts();
+  stopAmbient();
   const f = $('card-flip');
   if (!f) return;
-  const p = $('particles');
-  const b = $('burst');
   const glow = $('bg-glow');
-  const ripples = $('ripples');
-  const hearts = $('hearts');
-  const s = $('screen-draw');
+  const dust = $('dust');
+  const landing = $('landing');
+  const ambient = $('ambient');
   const a = $('draw-actions');
   const tilt = $('card-tilt');
   const front = document.querySelector('#card-flip .card-front');
 
   f.className = 'card-flip';
-  if (p) { p.className = 'particles'; p.innerHTML = ''; }
-  if (b) { b.className = 'burst'; b.innerHTML = ''; }
   if (glow) glow.className = 'bg-glow';
-  if (ripples) ripples.innerHTML = '';
-  if (hearts) hearts.innerHTML = '';
-  if (s) s.classList.remove('flash', 'preflash');
+  if (dust) dust.innerHTML = '';
+  if (landing) landing.innerHTML = '';
+  if (ambient) ambient.innerHTML = '';
+  $('card-ground')?.classList.remove('active');
+  $('reveal-streak')?.classList.remove('go');
   if (a) a.hidden = true;
   const preview = $('preview-actions');
   if (preview) preview.hidden = true;
-  stopRipples();
+  stopDust();
 
   detachTilt();
   if (tilt) {
@@ -505,7 +517,7 @@ export async function startDraw(pile) {
   previewMode = false;
   // Claim this generation. If unmount or a newer draw bumps the counter while
   // we await, stale() turns true and we bail; the bail itself touches no shared
-  // state (wake lock, ripples, hearts) so it can't clobber a concurrent draw,
+  // state (wake lock, dust, ambient) so it can't clobber a concurrent draw,
   // unmount having already cleaned those up. Returns true only on full
   // completion, so mount() skips its listener setup when we bailed.
   const myGen = ++drawGeneration;
@@ -543,16 +555,11 @@ export async function startDraw(pile) {
   playDraw();
 
   const f = $('card-flip');
-  const p = $('particles');
-  const b = $('burst');
   const glow = $('bg-glow');
-  const s = $('screen-draw');
   const a = $('draw-actions');
 
   f.classList.add(pile === 'home' ? 'glow-home' : 'glow-outdoor');
   const glowColor = pile === 'home' ? '#ffb47a' : '#8ab4ff';
-  createParticles(glowColor);
-  createBurst(glowColor);
 
   const reduced = prefersReducedMotion();
   void f.offsetWidth;
@@ -568,34 +575,36 @@ export async function startDraw(pile) {
     await wait(400);
     if (stale()) return false;
   } else {
+    // Charge: the card levitates while gold dust swirls into it.
     glow.classList.add('active');
-    p.classList.add('active');
-    f.classList.add('pulsing');
-    startRipples(CONFIG.ripples.normalInterval);
-    await wait(CONFIG.draw.pulsingDuration);
+    f.classList.add('charging');
+    startDust();
+    await wait(CONFIG.draw.chargeDuration);
     if (stale()) return false;
-    glow.classList.add('boost');
-    f.classList.remove('pulsing');
+    // Inhale: one sharp contraction before the release.
+    stopDust();
+    f.classList.remove('charging');
     f.classList.add('climax');
-    s.classList.add('preflash');
-    startRipples(CONFIG.ripples.boostInterval);
     await wait(CONFIG.draw.climaxDuration);
     if (stale()) return false;
-    stopRipples();
+    // Flip, with a light streak sweeping the face as it turns.
     f.classList.remove('climax');
     f.classList.add('flipping');
+    $('reveal-streak')?.classList.add('go');
     await wait(CONFIG.draw.flipDuration);
     if (stale()) return false;
   }
 
   f.classList.add('settled');
   f.classList.remove('flipping', 'enter');
-  s.classList.add('flash');
-  s.classList.remove('preflash');
-  b.classList.add('active');
-  p.classList.remove('active');
-  glow.classList.remove('active', 'boost');
-  stopRipples();
+  glow.classList.remove('active');
+  stopDust();
+  if (!reduced) {
+    spawnLanding(glowColor);
+    // Cascade the card text in and let the card float above its shadow.
+    f.classList.add('reveal-cascade', 'floaty');
+    $('card-ground')?.classList.add('active');
+  }
 
   const front = document.querySelector('#card-flip .card-front');
   front.classList.add('idle-shine');
@@ -607,7 +616,7 @@ export async function startDraw(pile) {
   announceCard(card);
   a.hidden = false;
   attachTilt();
-  startHearts();
+  startAmbient();
   return true;
 }
 
@@ -658,14 +667,14 @@ function doRedraw() {
   addHistory({ cardId: id, drawnAt: new Date().toISOString(), action: 'returned' });
   vibrate(CONFIG.vibrations.redrawAction);
   playRedraw();
-  stopHearts();
+  stopAmbient();
   if (pile) startDraw(pile);
 }
 
 // toastArg is either a string (plain toast) or { message, action } for a
 // snackbar with an action button.
 function finishWith(swipeClass, toastArg) {
-  stopHearts();
+  stopAmbient();
   refreshHomeCounts();
   releaseWakeLock();
   const tilt = $('card-tilt');
@@ -728,7 +737,7 @@ export function showCardDirectly(cardId) {
   if (preview) preview.hidden = false;
   updatePreviewActions(cardId);
   attachTilt();
-  // Skip the floating hearts and ambient ripples in preview mode: those are
+  // Skip the ambient dust and landing effects in preview mode: those are
   // tuned for the dramatic reveal flow, and replaying them every time the
   // user opens an already-known card from Collection or History feels heavy.
   return true;
@@ -822,19 +831,17 @@ function onVisibilityChange() {
     // Stop the ambient effects while the tab is backgrounded. Browsers
     // throttle background timers but still execute each tick (DOM node
     // create / setTimeout queue), and the visuals are invisible anyway.
-    stopHearts();
-    stopRipples();
+    stopAmbient();
+    stopDust();
     return;
   }
   bumpInactivity();
-  // Resume the hearts when the user is back and a card has been revealed
-  // (the settled class means the flip animation has landed). Ripples stay
-  // off: they only run during the pre-reveal build-up and are stopped for
-  // good once the card settles, so restarting them here would resurrect an
-  // infinite loop that never exists outside a tab switch.
-  // startHearts no-ops in preview, so no guard is needed here.
+  // Resume the ambient dust when the user is back and a card has been
+  // revealed (the settled class means the flip animation has landed). The
+  // converging dust stays off: it only runs during the pre-reveal build-up.
+  // startAmbient no-ops in preview, so no guard is needed here.
   if ($('card-flip')?.classList.contains('settled')) {
-    startHearts();
+    startAmbient();
   }
 }
 
@@ -884,8 +891,8 @@ export async function mount({ params }) {
 
 export function unmount() {
   document.removeEventListener('keydown', onDrawKeydown);
-  stopHearts();
-  stopRipples();
+  stopAmbient();
+  stopDust();
   detachTilt();
   releaseWakeLock();
   drawGeneration++; // invalidate any reveal animation still mid-await

--- a/public/js/ui/emoji.js
+++ b/public/js/ui/emoji.js
@@ -8,15 +8,6 @@ const BASE = '/icons/emoji';
 // player bundles do not pay the parse cost. The renderer accepts any
 // matching slug regardless of where the list comes from.
 
-export const HEART_KEYS = [
-  'heart-ribbon',
-  'growing-heart',
-  'sparkling-heart',
-  'two-hearts',
-  'heart-arrow',
-  'red-heart',
-];
-
 export function emojiUrl(slug) {
   return slug ? `${BASE}/${slug}.svg` : '';
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards: stale-while-revalidate (allows offline viewing)
 //   * all other /api/*: network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v48';
+const VERSION = 'couplecards-v49';
 const SHELL = [
   '/',
   '/index.html',

--- a/public/views/draw.html
+++ b/public/views/draw.html
@@ -6,10 +6,9 @@
   </div>
   <div class="draw-stage" id="draw-stage">
     <div class="bg-glow" id="bg-glow"></div>
-    <div class="ripples" id="ripples"></div>
-    <div class="particles" id="particles"></div>
-    <div class="burst" id="burst"></div>
-    <div class="hearts" id="hearts"></div>
+    <div class="fx-layer" id="dust"></div>
+    <div class="fx-layer" id="ambient"></div>
+    <div class="card-ground" id="card-ground" aria-hidden="true"></div>
     <div class="card-tilt" id="card-tilt">
       <div class="swipe-label swipe-label-ban" aria-hidden="true" data-i18n="draw.swipe.ban">Ban</div>
       <div class="swipe-label swipe-label-return" aria-hidden="true" data-i18n="draw.swipe.return">Return to the pile</div>
@@ -40,9 +39,11 @@
           </div>
           <div class="holo holo-rainbow"></div>
           <div class="holo holo-glare"></div>
+          <div class="reveal-streak" id="reveal-streak" aria-hidden="true"></div>
         </div>
       </div>
     </div>
+    <div class="fx-layer fx-above" id="landing"></div>
   </div>
   <div class="draw-actions" id="draw-actions" hidden>
     <button class="btn btn-md btn-danger" id="action-ban" aria-keyshortcuts="ArrowLeft" data-i18n="draw.action.ban">Ban</button>


### PR DESCRIPTION
Redesigns the card reveal animation, following user feedback that the current one felt dated. The direction ("gold dust") was chosen by the owner from an interactive side-by-side demo of three candidates.

## The new sequence

- **Charge**: the card levitates while roughly 200 golden motes swirl into it along arced paths, with a continuous inflow so the swirl densifies as tension rises. Depth is faked with per-mote size, blur, and opacity. An edge light builds along the card back.
- **Inhale**: one sharp contraction right before the release.
- **Flip**: a light streak sweeps across the face as the card turns, with a slight upward arc.
- **Landing**: a golden card-shaped shockwave replaces the old full-screen white flash, a dense ember fallout rains below the card, and the card text (label, title, divider, description) cascades in.
- **Rest**: the card floats gently over a breathing ground shadow, surrounded by a thin ambient dust that keeps drifting up.

## Retired

The wobble/shake build-up, the rectangular concentric ripples, the shard burst, the eight orbiting particles, the white flash, the anticipatory flash, and the floating emoji hearts. The `HEART_KEYS` export they used is removed too.

## Guardrails

- Particle counts halve on devices reporting 4 CPU cores or fewer; the choreography reads identically.
- `prefers-reduced-motion` keeps the existing behavior: short fade and flip, no particles, no float, text shown immediately; the new effects are gated both in JS (spawners no-op) and CSS.
- Preview mode (opening a card from Collection or History) stays a static viewer with no ambient effects.
- All effect nodes are transform/opacity animations with fixed lifetimes and removal timers; intervals are cleared on unmount, tab hide, and navigation, reusing the existing generation guard.

## Expected behaviors after merge

- Drawing a card plays the new sequence end to end (about 3.9 seconds, close to the previous total).
- No white flash at any point in the reveal.
- After the reveal, faint dust keeps floating around the card until the user acts.
- Tab switch pauses and resumes the ambient dust; leaving the screen cancels everything.

Verified locally: syntax checks, app boots and serves the updated view/CSS/JS, the view contains exactly the new effect hooks and none of the old ones, and the CSS/JS class names match one to one. The motion itself was validated visually by the owner on the interactive demo that this implementation reproduces.
