### PR TITLE
feat: interface motion and gold-dust coherence polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- Switching screens now plays a soft crossfade: the app had transition styles but never actually drove them, so every navigation was an abrupt content swap.
+- The rest of the interface now speaks the reveal's gold language: tapping a pile charges it with gold light instead of a brightness flash, the halo around the most recently drawn card in the Collection and the pile counter pop turn gold, the syncing indicator drops its lone cyan for gold, History gets gilded date separators with a gently staggered entrance, and the sign-in card receives the same parchment wash and gold hairline as the rest of the app.
+- Toasts, the sync banner, and dialogs now animate out instead of vanishing in one frame, the boot splash fades into the app, Collection tiles respond to touch, admin tabs gain hover states and the same glowing indicator as the bottom navigation, and every one of these animations is disabled under "reduce motion".
 - The card reveal was redesigned around a "gold dust" sequence. The card now levitates while golden particles swirl into it, takes a sharp breath, then flips with a light sweep across its face; the landing sends out a golden shockwave (the full-screen white flash is gone), embers rain down, the card text cascades in, and the revealed card keeps floating gently over its shadow surrounded by a thin ambient dust. The floating emoji hearts are retired in favor of that ambient dust, and particle density adapts to the device so low-end phones get the same choreography with fewer particles.
 - The Docker image is roughly half as large: file ownership is set during copy instead of in a duplicating chown layer.
 - `/api/health` no longer exposes the app version publicly; it only reports liveness.

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -30,10 +30,35 @@ body { padding: 20px 16px calc(env(safe-area-inset-bottom, 0px) + 24px); }
   padding: 8px 14px;
   border-radius: var(--radius-sm);
   cursor: pointer;
+  position: relative;
+  transition: color 0.18s ease, background-color 0.18s ease;
+}
+@media (hover: hover) {
+  .admin-tab:hover {
+    color: var(--text);
+    background: rgba(255, 255, 255, 0.05);
+  }
 }
 .admin-tab.active {
   color: var(--text);
   background: rgba(236, 90, 158, 0.12);
+}
+/* Glowing underline indicator, same treatment as the app's bottom nav. */
+.admin-tab.active::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -9px;
+  transform: translateX(-50%);
+  width: 28px;
+  height: 2px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  box-shadow: 0 0 10px rgba(236, 90, 158, 0.5);
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .admin-tab { transition: none; }
 }
 .admin-tab-right {
   margin-left: auto;
@@ -47,24 +72,7 @@ body { padding: 20px 16px calc(env(safe-area-inset-bottom, 0px) + 24px); }
   mask-image: none;
   -webkit-mask-image: none;
 }
-.admin-search input {
-  width: 100%;
-  background-color: rgba(255, 255, 255, 0.06);
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff80' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='11' cy='11' r='8'/><line x1='21' y1='21' x2='16.65' y2='16.65'/></svg>");
-  background-repeat: no-repeat;
-  background-position: 14px center;
-  background-size: 16px 16px;
-  border: 1px solid var(--surface-border);
-  color: var(--text);
-  padding: 8px 14px 8px 38px;
-  border-radius: 999px;
-  font-family: inherit;
-  font-size: 0.9rem;
-}
-.admin-search input:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
+/* Input styling shared with the Collection search, see style.css. */
 
 .admin-panel {
   max-width: 720px;
@@ -331,5 +339,5 @@ body { padding: 20px 16px calc(env(safe-area-inset-bottom, 0px) + 24px); }
   color: var(--text-muted);
 }
 .deck-sync-summary .is-danger {
-  color: #ff6b8a;
+  color: var(--danger-bright);
 }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -152,29 +152,40 @@
   font-size: 0.82rem;
   font-weight: 600;
   color: var(--text);
-  background: rgba(15, 8, 32, 0.92);
+  background-image: var(--tile-surface);
+  background-color: rgba(20, 10, 40, 0.92);
   border: 1px solid var(--surface-border);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  box-shadow: inset 0 1px 0 rgba(255, 210, 150, 0.25), 0 6px 20px rgba(0, 0, 0, 0.4);
   margin: 0 auto;
   width: max-content;
   max-width: calc(100% - 24px);
+  animation: sync-banner-in 0.25s var(--ease-out);
+}
+.sync-banner.leaving { animation: sync-banner-out 0.18s ease forwards; }
+@keyframes sync-banner-in {
+  from { opacity: 0; transform: translateY(8px); }
+}
+@keyframes sync-banner-out {
+  to { opacity: 0; transform: translateY(8px); }
 }
 .sync-dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
-  background: #9aa3b8;
+  background: var(--text-muted);
 }
 .sync-banner.is-offline .sync-dot {
-  background: #ff7a7a;
-  box-shadow: 0 0 8px rgba(255, 122, 122, 0.6);
+  background: var(--danger);
+  box-shadow: 0 0 8px rgba(255, 102, 119, 0.6);
 }
+/* Gold while syncing: the dust is settling. Cyan was the one hue the
+   product palette never uses anywhere else. */
 .sync-banner.is-syncing .sync-dot {
-  background: #6bd0ff;
-  box-shadow: 0 0 8px rgba(107, 208, 255, 0.6);
+  background: #ffd37a;
+  box-shadow: 0 0 8px rgba(255, 211, 122, 0.6);
   animation: sync-pulse 1.4s ease-in-out infinite;
 }
 @keyframes sync-pulse {
@@ -183,5 +194,7 @@
 }
 @media (prefers-reduced-motion: reduce) {
   .sync-banner.is-syncing .sync-dot { animation: none; }
+  .sync-banner { animation: none; }
+  .sync-banner.leaving { animation: none; opacity: 0; }
 }
 

--- a/public/css/auth.css
+++ b/public/css/auth.css
@@ -21,19 +21,34 @@ body { font-family: var(--font); }
 }
 
 .auth-card {
+  position: relative;
   width: 100%;
   max-width: 440px;
-  background: var(--surface);
+  background-image: var(--tile-surface);
+  background-color: var(--surface);
   border: 1px solid var(--surface-border);
   border-radius: var(--radius-lg);
   padding: 28px;
   box-shadow: var(--shadow-lg);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
+  overflow: hidden;
+}
+/* Warm gold hairline along the top edge, same parchment family as the
+   in-app tiles and the bottom nav. */
+.auth-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 14%;
+  right: 14%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 210, 150, 0.45), transparent);
+  pointer-events: none;
 }
 
 .auth-title {
-  font-family: var(--font);
+  font-family: var(--font-display);
   font-size: 1.8rem;
   font-weight: 600;
   letter-spacing: -0.015em;

--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -74,16 +74,16 @@
 }
 .swipe-label-ban {
   right: 20px;
-  color: #ff6680;
-  border-color: #ff6680;
+  color: var(--danger-bright);
+  border-color: var(--danger-bright);
   transform: rotate(14deg);
   text-shadow: 0 2px 10px rgba(255, 102, 128, 0.4);
   box-shadow: 0 4px 18px rgba(255, 102, 128, 0.25);
 }
 .swipe-label-return {
   left: 20px;
-  color: #4ee09a;
-  border-color: #4ee09a;
+  color: var(--success-bright);
+  border-color: var(--success-bright);
   transform: rotate(-14deg);
   text-shadow: 0 2px 10px rgba(78, 224, 154, 0.4);
   box-shadow: 0 4px 18px rgba(78, 224, 154, 0.25);
@@ -899,7 +899,7 @@
   gap: 8px;
   max-width: 420px;
   margin: 0 auto;
-  animation: actions-in 0.35s cubic-bezier(0.2, 0.8, 0.2, 1);
+  animation: actions-in 0.35s var(--ease-out);
 }
 .preview-actions {
   grid-template-columns: 1fr;
@@ -1106,24 +1106,7 @@
   display: block;
   width: 100%;
 }
-.collection-search input {
-  width: 100%;
-  background-color: rgba(255, 255, 255, 0.06);
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff80' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='11' cy='11' r='8'/><line x1='21' y1='21' x2='16.65' y2='16.65'/></svg>");
-  background-repeat: no-repeat;
-  background-position: 14px center;
-  background-size: 16px 16px;
-  border: 1px solid var(--surface-border);
-  color: var(--text);
-  padding: 8px 14px 8px 38px;
-  border-radius: 999px;
-  font-family: inherit;
-  font-size: 0.9rem;
-}
-.collection-search input:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
+/* Input styling shared with the admin search, see style.css. */
 
 .collection-grid {
   display: grid;
@@ -1151,6 +1134,9 @@
     box-shadow: 0 8px 22px rgba(0, 0, 0, 0.45);
   }
 }
+/* Tap feedback: the native highlight is disabled above, so give touch users
+   a press response of our own. */
+.coll-tile[role='button']:active { transform: scale(0.97); }
 .coll-tile[role='button']:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -1285,7 +1271,7 @@
 .coll-tile-cross svg {
   width: 55%;
   height: 55%;
-  color: #ff5560;
+  color: var(--danger-bright);
   filter: drop-shadow(0 0 6px rgba(255, 60, 80, 0.55));
 }
 
@@ -1323,16 +1309,18 @@
 .coll-tile.is-fresh {
   animation: coll-tile-fresh 2.2s ease-in-out 4;
 }
+/* Gold ring: the card the gold-dust reveal just produced is haloed in the
+   same gold when the user comes looking for it here. */
 @keyframes coll-tile-fresh {
   0%, 100% {
-    outline: 2px solid rgba(236, 90, 158, 0.55);
+    outline: 2px solid rgba(255, 211, 122, 0.55);
     outline-offset: 1px;
-    box-shadow: 0 0 0 0 rgba(236, 90, 158, 0), 0 4px 14px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 0 0 0 rgba(255, 211, 122, 0), 0 4px 14px rgba(0, 0, 0, 0.35);
   }
   50% {
-    outline: 2px solid rgba(236, 90, 158, 0.95);
+    outline: 2px solid rgba(255, 211, 122, 0.95);
     outline-offset: 3px;
-    box-shadow: 0 0 18px 4px rgba(236, 90, 158, 0.55), 0 4px 14px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 0 18px 4px rgba(255, 211, 122, 0.55), 0 4px 14px rgba(0, 0, 0, 0.35);
   }
 }
 
@@ -1340,7 +1328,7 @@
   .coll-tile { transition: none; }
   .coll-tile.is-fresh {
     animation: none;
-    outline: 2px solid rgba(236, 90, 158, 0.85);
+    outline: 2px solid rgba(255, 211, 122, 0.85);
     outline-offset: 2px;
   }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -368,14 +368,14 @@ body::before {
   user-select: none;
 }
 .stamp-banned {
-  color: #ff6680;
-  border-color: #ff6680;
+  color: var(--danger-bright);
+  border-color: var(--danger-bright);
   transform: rotate(-8deg);
   text-shadow: 0 1px 4px rgba(255, 102, 128, 0.35);
 }
 .stamp-returned {
-  color: #4ee09a;
-  border-color: #4ee09a;
+  color: var(--success-bright);
+  border-color: var(--success-bright);
   transform: rotate(-8deg);
   text-shadow: 0 1px 4px rgba(78, 224, 154, 0.35);
 }
@@ -470,7 +470,7 @@ body::before {
   display: block;
   aspect-ratio: 3 / 4;
   min-height: 140px;
-  transition: transform 0.25s cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: transform 0.25s var(--ease-out);
 }
 @media (hover: hover) {
   .pile:hover { transform: translateY(-5px); filter: brightness(1.05); }
@@ -487,14 +487,27 @@ body::before {
 }
 .pile:disabled:hover,
 .pile.empty:hover { transform: none; }
+/* Launch: the pile charges with the same gold light as the card reveal
+   (no brightness flash; that language was retired with the old reveal). */
 .pile.launching {
   pointer-events: none;
   animation: pile-launch 0.45s cubic-bezier(0.4, 0, 0.6, 1) forwards;
 }
 @keyframes pile-launch {
   0%   { transform: scale(1) rotate(0deg); }
-  40%  { transform: scale(1.12) rotate(-3deg); filter: brightness(1.2); }
-  100% { transform: scale(1.35) rotate(-5deg) translateY(-12px); opacity: 0; filter: brightness(1.4); }
+  40%  { transform: scale(1.1) rotate(-3deg); }
+  100% { transform: scale(1.3) rotate(-5deg) translateY(-12px); opacity: 0; }
+}
+.pile.launching .stack-card {
+  animation: pile-launch-glow 0.45s ease-out forwards;
+}
+@keyframes pile-launch-glow {
+  to {
+    box-shadow:
+      0 18px 40px rgba(0, 0, 0, 0.55),
+      0 0 34px rgba(255, 211, 122, 0.55),
+      0 0 0 1.5px rgba(255, 220, 160, 0.6) inset;
+  }
 }
 
 .stack-card {
@@ -503,7 +516,7 @@ body::before {
   box-shadow:
     0 18px 40px rgba(0, 0, 0, 0.55),
     0 0 0 1px rgba(255, 255, 255, 0.08) inset;
-  transition: transform 0.25s cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: transform 0.25s var(--ease-out);
 }
 
 .stack-card-3 {
@@ -639,8 +652,8 @@ body::before {
   text-shadow: 0 1px 4px rgba(255, 176, 80, 0.4);
 }
 @keyframes count-pop {
-  0%   { transform: scale(1); background: rgba(236, 90, 158, 0.5); }
-  40%  { transform: scale(1.15); background: rgba(236, 90, 158, 0.45); }
+  0%   { transform: scale(1); background: rgba(255, 211, 122, 0.45); }
+  40%  { transform: scale(1.15); background: rgba(255, 211, 122, 0.4); }
   100% { transform: scale(1); background: rgba(0, 0, 0, 0.28); }
 }
 
@@ -703,7 +716,7 @@ body::before {
 }
 .action-tag.returned {
   background: rgba(47, 207, 138, 0.18);
-  color: #3ddb96;
+  color: var(--success-bright);
 }
 .action-tag.banned {
   background: color-mix(in srgb, var(--danger) 18%, transparent);
@@ -821,7 +834,7 @@ body::before {
   left: 3px; top: 3px;
   background: #fff;
   border-radius: 50%;
-  transition: transform 0.22s cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: transform 0.22s var(--ease-out);
   box-shadow: 0 2px 6px rgba(0,0,0,0.2);
 }
 .switch input:checked + .slider {
@@ -895,26 +908,35 @@ body::before {
   opacity: 0.75;
 }
 
-/* Toast */
+/* Toast: same dark-glass recipe as the other floating surfaces (update and
+   sync banners), with the warm gold top highlight of the parchment family. */
 .toast {
   position: fixed;
   left: 50%;
   bottom: calc(env(safe-area-inset-bottom, 0px) + 24px);
   transform: translateX(-50%);
-  background: var(--text);
-  color: var(--bg-0);
+  background-image: var(--tile-surface);
+  background-color: rgba(20, 10, 40, 0.92);
+  color: var(--text);
+  border: 1px solid var(--surface-border);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   padding: 11px 20px;
   border-radius: 999px;
   font-size: 0.9rem;
   font-weight: 600;
-  box-shadow: var(--shadow-lg);
+  box-shadow: inset 0 1px 0 rgba(255, 210, 150, 0.25), var(--shadow-lg);
   z-index: 1000;
-  animation: toast-in 0.22s cubic-bezier(0.2, 0.8, 0.2, 1);
+  animation: toast-in 0.22s var(--ease-out);
   max-width: calc(100vw - 32px);
   text-align: center;
   display: inline-flex;
   align-items: center;
   gap: 12px;
+}
+.toast.leaving { animation: toast-out 0.18s ease forwards; }
+@keyframes toast-out {
+  to { opacity: 0; transform: translate(-50%, 12px); }
 }
 
 .toast-action {
@@ -932,8 +954,11 @@ body::before {
   padding: 2px 4px;
 }
 
-/* History grouping by date */
+/* History grouping by date, with the gold hairline of the parchment family. */
 .history-group-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.18em;
@@ -941,6 +966,12 @@ body::before {
   color: var(--text-muted);
   padding: 10px 4px 6px;
   margin-top: 6px;
+}
+.history-group-header::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 210, 150, 0.3), transparent);
 }
 .history-group-header:first-child { margin-top: 0; padding-top: 0; }
 
@@ -953,6 +984,15 @@ body::before {
   background: rgba(255, 255, 255, 0.04);
 }
 .list-item.clickable:active { transform: scale(0.99); }
+
+/* Staggered entrance for freshly rendered lists (History). --i is set in JS
+   and capped there so long lists never feel slow. */
+.list-item.stagger-in {
+  animation: list-item-in 0.35s var(--ease-out) calc(var(--i, 0) * 45ms) backwards;
+}
+@keyframes list-item-in {
+  from { opacity: 0; transform: translateY(10px); }
+}
 
 /* Modal */
 .modal {
@@ -995,6 +1035,16 @@ body::before {
   from { opacity: 0; transform: translateY(14px) scale(0.97); }
   to   { opacity: 1; transform: translateY(0) scale(1); }
 }
+/* Symmetric exit: shell.js adds .closing and hides the modal after the
+   animation instead of cutting the blur and card off in one frame. */
+.modal.closing .modal-backdrop { animation: backdrop-out 0.16s ease forwards; }
+.modal.closing .modal-card { animation: modal-out 0.16s ease forwards; }
+@keyframes backdrop-out {
+  to { opacity: 0; }
+}
+@keyframes modal-out {
+  to { opacity: 0; transform: translateY(8px) scale(0.98); }
+}
 .modal-title {
   margin: 0 0 8px;
   font-size: 1.2rem;
@@ -1027,7 +1077,11 @@ body::before {
   /* Transparent so the body's radial+linear gradient shows through and
      dismissing the skeleton does not flash a flat fill behind it. */
   background: transparent;
+  transition: opacity 0.22s ease;
 }
+/* Soft handoff into the app: the boot logo shares the home wordmark rule, so
+   a plain fade already reads as the logo settling into the header. */
+.boot-skeleton.leaving { opacity: 0; pointer-events: none; }
 .boot-logo {
   animation: boot-logo-pulse 1.2s ease-in-out infinite;
 }
@@ -1058,13 +1112,16 @@ body::before {
   align-items: center;
   gap: 12px;
   padding: 10px 10px 10px 18px;
-  background: var(--surface-solid);
+  background-image: var(--tile-surface);
+  background-color: rgba(20, 10, 40, 0.92);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   border: 1px solid var(--surface-border);
   border-radius: 999px;
-  box-shadow: var(--shadow-lg);
+  box-shadow: inset 0 1px 0 rgba(255, 210, 150, 0.25), var(--shadow-lg);
   z-index: 900;
   font-size: 0.85rem;
-  animation: toast-in 0.25s cubic-bezier(0.2, 0.8, 0.2, 1);
+  animation: toast-in 0.25s var(--ease-out);
   max-width: calc(100vw - 32px);
 }
 .update-banner[hidden] { display: none; }
@@ -1072,6 +1129,31 @@ body::before {
 @keyframes toast-in {
   from { opacity: 0; transform: translate(-50%, 12px); }
   to   { opacity: 1; transform: translate(-50%, 0); }
+}
+
+/* Shared pill search field (Collection and admin lists). One recipe so the
+   two screens read identically; the focus glow warms the outline up. */
+.collection-search input,
+.admin-search input {
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.06);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffffff80' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><circle cx='11' cy='11' r='8'/><line x1='21' y1='21' x2='16.65' y2='16.65'/></svg>");
+  background-repeat: no-repeat;
+  background-position: 14px center;
+  background-size: 16px 16px;
+  border: 1px solid var(--surface-border);
+  color: var(--text);
+  padding: 8px 14px 8px 38px;
+  border-radius: 999px;
+  font-family: inherit;
+  font-size: 0.9rem;
+  transition: box-shadow 0.18s ease, border-color 0.18s ease;
+}
+.collection-search input:focus-visible,
+.admin-search input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(236, 90, 158, 0.15);
 }
 
 /* ===== Forms shared by login.html, admin.html and the change-password modal ===== */
@@ -1243,3 +1325,25 @@ select option:hover {
 }
 .error-page .title { font-size: 2rem; margin-bottom: 12px; }
 .error-page p { color: var(--text-soft); margin-bottom: 24px; }
+
+/* Consolidated reduced-motion coverage for the shell animations above.
+   Elements that JS hides after a .leaving/.closing animation still get
+   hidden: the JS uses a timeout, not the animationend event. */
+@media (prefers-reduced-motion: reduce) {
+  .pile.launching { animation: none; opacity: 0; }
+  .pile.launching .stack-card { animation: none; }
+  .pile-count.count-changed { animation: none; }
+  .toast,
+  .update-banner { animation: none; }
+  .toast.leaving { animation: none; opacity: 0; }
+  .modal-backdrop,
+  .modal-card { animation: none; }
+  .modal.closing .modal-backdrop,
+  .modal.closing .modal-card { animation: none; }
+  .boot-logo,
+  .boot-pulse { animation: none; }
+  .boot-skeleton { transition: none; }
+  .list-item.stagger-in { animation: none; }
+  .collection-search input,
+  .admin-search input { transition: none; }
+}

--- a/public/css/themes.css
+++ b/public/css/themes.css
@@ -35,6 +35,10 @@
 
   --danger: #ff6677;
   --success: #2fcf8a;
+  /* Brighter variants for glowing stamps and labels sitting on the dark
+     card faces, where the base tones lack punch. */
+  --danger-bright: #ff6680;
+  --success-bright: #4ee09a;
 
   --shadow-sm: 0 2px 10px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.45);

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -38,7 +38,13 @@ async function boot() {
   const outlet = document.getElementById('view');
   setOutlet(outlet);
 
-  document.getElementById('boot-skeleton')?.remove();
+  // Fade the boot splash into the app instead of cutting; the logo shares
+  // the home wordmark styling, so the fade reads as a soft handoff.
+  const skeleton = document.getElementById('boot-skeleton');
+  if (skeleton) {
+    skeleton.classList.add('leaving');
+    setTimeout(() => skeleton.remove(), 250);
+  }
   document.getElementById('app')?.removeAttribute('hidden');
 
   wireBottomNav();

--- a/public/js/core/router.js
+++ b/public/js/core/router.js
@@ -76,8 +76,21 @@ export async function render() {
 
   const html = await loadPartial(segment);
   if (gen !== renderGen) return;
-  outlet.innerHTML = html;
-  applyI18n(outlet);
+  // Animate the swap through the View Transitions API where available (the
+  // ::view-transition rules in style.css do the crossfade). The update
+  // callback runs asynchronously, so wait for it before mounting into the
+  // new DOM. Reduced motion and unsupported browsers keep the instant swap.
+  const swap = () => {
+    outlet.innerHTML = html;
+    applyI18n(outlet);
+  };
+  if (document.startViewTransition
+    && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    await document.startViewTransition(swap).updateCallbackDone;
+    if (gen !== renderGen) return;
+  } else {
+    swap();
+  }
 
   const module = await features.get(segment)();
   if (gen !== renderGen) return;

--- a/public/js/features/history/history.js
+++ b/public/js/features/history/history.js
@@ -55,6 +55,8 @@ function render() {
     return;
   }
 
+  // Staggered entrance, capped so long histories never feel slow to load.
+  let stagger = 0;
   for (const group of groupByDate(history)) {
     const header = document.createElement('div');
     header.className = 'history-group-header';
@@ -68,7 +70,8 @@ function render() {
       const foil = !!card?.foil;
 
       const div = document.createElement('div');
-      div.className = 'list-item';
+      div.className = 'list-item stagger-in';
+      div.style.setProperty('--i', String(Math.min(stagger++, 8)));
       if (card) {
         div.classList.add('clickable');
         div.setAttribute('role', 'button');

--- a/public/js/ui/shell.js
+++ b/public/js/ui/shell.js
@@ -39,6 +39,17 @@ export function toast(message, options = {}) {
   const el = document.getElementById('toast');
   if (!el) return;
   clearTimeout(toast._timer);
+  clearTimeout(toast._hideTimer);
+  el.classList.remove('leaving');
+  // Animated dismissal; the timeout (not animationend) hides the element so
+  // reduced motion, where the animation is disabled, still ends hidden.
+  const dismiss = () => {
+    el.classList.add('leaving');
+    toast._hideTimer = setTimeout(() => {
+      el.hidden = true;
+      el.classList.remove('leaving');
+    }, 200);
+  };
   const action = options.action || null;
   const duration = options.duration ?? (action ? 5000 : 1800);
   el.replaceChildren(document.createTextNode(message));
@@ -49,13 +60,31 @@ export function toast(message, options = {}) {
     btn.textContent = action.label;
     btn.addEventListener('click', () => {
       clearTimeout(toast._timer);
-      el.hidden = true;
+      dismiss();
       try { action.onClick(); } catch {}
     });
     el.appendChild(btn);
   }
   el.hidden = false;
-  toast._timer = setTimeout(() => { el.hidden = true; }, duration);
+  toast._timer = setTimeout(dismiss, duration);
+}
+
+// Animated modal dismissal shared by showConfirm and withModal. The timeout
+// (not animationend) hides the element so reduced motion, where the
+// animations are disabled, still ends hidden.
+let modalCloseTimer = 0;
+function openModalHost(host) {
+  clearTimeout(modalCloseTimer);
+  host.classList.remove('closing');
+  host.hidden = false;
+}
+function closeModalHost(host) {
+  host.classList.add('closing');
+  clearTimeout(modalCloseTimer);
+  modalCloseTimer = setTimeout(() => {
+    host.hidden = true;
+    host.classList.remove('closing');
+  }, 170);
 }
 
 // Generic confirmation modal with a focus trap. Resolves to true/false.
@@ -89,7 +118,7 @@ export function showConfirm({
     const focusables = () => [cancelBtn, confirmBtn].filter((b) => !b.hidden);
 
     const close = (result) => {
-      modal.hidden = true;
+      closeModalHost(modal);
       confirmBtn.removeEventListener('click', onConfirm);
       cancelBtn.removeEventListener('click', onCancel);
       modal.querySelector('[data-modal-close]')?.removeEventListener('click', onCancel);
@@ -127,7 +156,7 @@ export function showConfirm({
     modal.querySelector('[data-modal-close]')?.addEventListener('click', onCancel);
     document.addEventListener('keydown', onKey);
 
-    modal.hidden = false;
+    openModalHost(modal);
     setTimeout(() => confirmBtn.focus(), 50);
   });
 }
@@ -161,14 +190,14 @@ export function withModal({ title, bodyHtml, confirmLabel, cancelLabel, danger, 
   const showCancel = cancelLabel != null;
   cancelBtn.hidden = !showCancel;
   if (showCancel) cancelBtn.textContent = cancelLabel;
-  host.hidden = false;
+  openModalHost(host);
 
   const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
   const getFocusables = () => Array.from(host.querySelectorAll(FOCUSABLE))
     .filter((el) => !el.hidden && el.offsetParent !== null);
 
   const close = () => {
-    host.hidden = true;
+    closeModalHost(host);
     confirmBtn.removeEventListener('click', handler);
     cancelBtn.removeEventListener('click', cancel);
     backdrop?.removeEventListener('click', cancel);
@@ -300,27 +329,41 @@ function showUpdateBanner(worker) {
 // "Syncing your changes…" when the outbox has pending writes that have not
 // reached the server yet. Hidden once everything settles.
 let syncPending = 0;
+let syncBannerHideTimer = 0;
 
 function refreshSyncBanner() {
   const banner = document.getElementById('sync-banner');
   const text = document.getElementById('sync-banner-text');
   if (!banner || !text) return;
+  const show = () => {
+    clearTimeout(syncBannerHideTimer);
+    banner.classList.remove('leaving');
+    banner.hidden = false;
+  };
   const offline = !navigator.onLine;
   if (offline) {
     text.textContent = t('common.offline');
     banner.classList.remove('is-syncing');
     banner.classList.add('is-offline');
-    banner.hidden = false;
+    show();
     return;
   }
   if (syncPending > 0) {
     text.textContent = t('common.syncPending');
     banner.classList.remove('is-offline');
     banner.classList.add('is-syncing');
-    banner.hidden = false;
+    show();
     return;
   }
-  banner.hidden = true;
+  // Animated exit; the timeout (not animationend) hides the banner so
+  // reduced motion, where the animation is disabled, still ends hidden.
+  if (!banner.hidden && !banner.classList.contains('leaving')) {
+    banner.classList.add('leaving');
+    syncBannerHideTimer = setTimeout(() => {
+      banner.hidden = true;
+      banner.classList.remove('leaving');
+    }, 200);
+  }
 }
 
 export function initSyncBanner() {

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards: stale-while-revalidate (allows offline viewing)
 //   * all other /api/*: network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v49';
+const VERSION = 'couplecards-v50';
 const SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
Interface-wide motion and coherence polish, following the gold-dust reveal (#99). No layout or information-architecture changes; every item is presentation-only.

## Motion

- Navigation finally animates: the `::view-transition` styles existed but nothing ever called `document.startViewTransition`, so every screen change was an abrupt content swap. The router now drives the API where supported; reduced motion and other browsers keep the instant swap.
- Toasts, the sync banner, and dialogs animate out instead of disappearing in one frame; the boot splash fades into the app (the boot logo shares the home wordmark styling, so it reads as a handoff). Exits are timeout-driven, so reduced motion still ends hidden.
- History entries fade up with a small stagger (capped at 8 steps); Collection tiles respond to touch with a press scale.

## Gold-dust coherence

- Tapping a pile now charges it with gold light; the old animation ended in a `brightness(1.4)` flash, the exact language #99 retired, on the very tap that leads into the redesigned reveal. It also honors reduced motion, which it previously ignored.
- Retinted to gold: the home counter pop (was pink), the "most recently drawn" halo in the Collection (was pink; it now matches the gold the reveal just showered on that card), and the syncing indicator (was cyan, a hue found nowhere else in the palette).
- History date separators get the parchment gold hairline; the sign-in card receives the same parchment wash, gold top hairline, and display-face title as the in-app tiles, so login no longer looks like an older generation of the product.

## Consistency

- Toast moves off the inverted white pill (the only light surface in the app) onto the shared dark-glass recipe now used by all three floating surfaces.
- New `--success-bright` / `--danger-bright` tokens replace the four drifting green/red hexes; the recurring easing curves now use the motion tokens from themes.css (exact-value substitutions only).
- The Collection and admin search inputs share one rule with a warm focus glow; admin tabs gain hover states and the same glowing underline as the bottom navigation.
- A consolidated reduced-motion block covers every previously unguarded shell animation (pile launch, counter pop, toast, banners, modal in/out, boot pulse, list stagger).

## Expected behaviors after merge

- Switching tabs in the bottom navigation crossfades smoothly (Chromium and Safari 18+; Firefox keeps the instant swap).
- Dismissing a dialog or a toast plays a short exit instead of a hard cut.
- After drawing a card, the fresh-card halo in the Collection is gold.
- With "reduce motion" enabled, none of the new animations play and everything still appears and hides correctly.

Verified locally: syntax checks on all touched JS, balanced braces across all stylesheets, no `var()` inside `rgba()`, old hexes gone except the token definitions, both standalone pages load the stylesheet that now hosts the shared search rule, and the app serves all modified assets.
