### PR TITLE
feat: float previewed cards like revealed ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- A card opened from Collection or History now floats over its ground shadow like a freshly revealed one; the one-shot reveal effects (dust, shockwave, text cascade) stay reserved for live draws.
 - Switching screens now plays a soft crossfade: the app had transition styles but never actually drove them, so every navigation was an abrupt content swap.
 - The rest of the interface now speaks the reveal's gold language: tapping a pile charges it with gold light instead of a brightness flash, the halo around the most recently drawn card in the Collection and the pile counter pop turn gold, the syncing indicator drops its lone cyan for gold, History gets gilded date separators with a gently staggered entrance, and the sign-in card receives the same parchment wash and gold hairline as the rest of the app.
 - Toasts, the sync banner, and dialogs now animate out instead of vanishing in one frame, the boot splash fades into the app, Collection tiles respond to touch, admin tabs gain hover states and the same glowing indicator as the bottom navigation, and every one of these animations is disabled under "reduce motion".

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -732,14 +732,20 @@ export function showCardDirectly(cardId) {
   const preview = $('preview-actions');
   f.classList.add(pile === 'home' ? 'glow-home' : 'glow-outdoor');
   f.classList.add('settled');
+  // The previewed card floats over its shadow like a freshly revealed one,
+  // so the object feels alive everywhere it appears. The one-shot effects
+  // (dust, landing shockwave, text cascade) stay reserved for the live
+  // reveal: replaying them on every card opened from Collection or History
+  // would turn them into noise.
+  if (!prefersReducedMotion()) {
+    f.classList.add('floaty');
+    $('card-ground')?.classList.add('active');
+  }
   frontEl.classList.add('idle-shine');
   announceCard(card);
   if (preview) preview.hidden = false;
   updatePreviewActions(cardId);
   attachTilt();
-  // Skip the ambient dust and landing effects in preview mode: those are
-  // tuned for the dramatic reveal flow, and replaying them every time the
-  // user opens an already-known card from Collection or History feels heavy.
   return true;
 }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards: stale-while-revalidate (allows offline viewing)
 //   * all other /api/*: network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v50';
+const VERSION = 'couplecards-v51';
 const SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
A card opened in preview from Collection or History was fully static, while a freshly revealed card floats over a breathing ground shadow. The previewed card now floats the same way, so the card reads as the same living object everywhere it appears.

Deliberately kept out of preview: the converging dust, the landing shockwave, and the text cascade. Those are one-shot dramatic effects tuned for the reveal; replaying them on every card opened while browsing would turn them into noise. Reduced motion keeps the static preview.

Expected behavior after merge: opening any card from Collection or History shows it gently floating over its shadow, exactly like a card that has just been drawn; closing and reopening previews stays clean (the stage reset already clears both classes).
