### PR TITLE
chore(release): cut version 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-07-05
+
 ### Fixed
 
 - Undo now sticks. Tapping "Undo" on the ban or return toast previously only reverted the change locally, so the entry silently came back in History and Collection on the next reload; the undo now also removes it on the server, including when it happens offline.
@@ -29,11 +31,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- A card opened from Collection or History now floats over its ground shadow like a freshly revealed one; the one-shot reveal effects (dust, shockwave, text cascade) stay reserved for live draws.
+- The card reveal was redesigned around a "gold dust" sequence. The card levitates while golden particles swirl into it, takes a sharp breath, then flips with a light sweep; the landing sends out a golden shockwave (the full-screen white flash is gone), embers rain down, the card text cascades in, and the revealed card keeps floating over its shadow surrounded by a thin ambient dust. The floating emoji hearts are retired in favor of that dust, and particle density adapts to the device.
+- A card opened from Collection or History now floats over its ground shadow like a freshly revealed one; the one-shot reveal effects stay reserved for live draws.
 - Switching screens now plays a soft crossfade: the app had transition styles but never actually drove them, so every navigation was an abrupt content swap.
 - The rest of the interface now speaks the reveal's gold language: tapping a pile charges it with gold light instead of a brightness flash, the halo around the most recently drawn card in the Collection and the pile counter pop turn gold, the syncing indicator drops its lone cyan for gold, History gets gilded date separators with a gently staggered entrance, and the sign-in card receives the same parchment wash and gold hairline as the rest of the app.
 - Toasts, the sync banner, and dialogs now animate out instead of vanishing in one frame, the boot splash fades into the app, Collection tiles respond to touch, admin tabs gain hover states and the same glowing indicator as the bottom navigation, and every one of these animations is disabled under "reduce motion".
-- The card reveal was redesigned around a "gold dust" sequence. The card now levitates while golden particles swirl into it, takes a sharp breath, then flips with a light sweep across its face; the landing sends out a golden shockwave (the full-screen white flash is gone), embers rain down, the card text cascades in, and the revealed card keeps floating gently over its shadow surrounded by a thin ambient dust. The floating emoji hearts are retired in favor of that ambient dust, and particle density adapts to the device so low-end phones get the same choreography with fewer particles.
 - The Docker image is roughly half as large: file ownership is set during copy instead of in a duplicating chown layer.
 - `/api/health` no longer exposes the app version publicly; it only reports liveness.
 - Seed files are validated at first boot with the same rules as the admin "sync from files" operation; malformed files are skipped with a warning instead of seeding unvalidated data.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -6,7 +6,7 @@ Audience: maintainers and contributors. This page summarizes what the app implem
 
 - Meet WCAG 2.1 AA contrast ratios for text and interactive elements.
 - Guarantee full keyboard operability. No screen in the app relies on a mouse-only interaction path.
-- Respect `prefers-reduced-motion` by disabling the 3D tilt, sparkle animations, and ripple effects.
+- Respect `prefers-reduced-motion` by disabling the 3D tilt, the gold-dust and ember particles, the card levitation, the screen transitions, and every other decorative animation.
 - Respect `prefers-color-scheme`. The dark theme is the default and no screen forces a specific color scheme.
 - Announce important state changes to screen readers through `aria-live` regions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/compress": "^9.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "private": true,
   "type": "module",
   "description": "Couplecards backend — Fastify + node:sqlite",


### PR DESCRIPTION
Cuts version 1.12.0: promotes the `[Unreleased]` section to `[1.12.0] - 2026-07-05`, bumps the version in both package manifests and their lockfiles, and refreshes the reduced-motion inventory in the accessibility doc.

The release gathers today's work: the two review passes (34 fixes, including the migration data-loss guard, durable undo, expired-lockout reset, and the nginx CSP passthrough), the gold-dust card reveal, the interface-wide motion and coherence polish, the floating preview cards, and the densified ambient dust.

After merge, the `v1.12.0` tag triggers the Release workflow, which builds and pushes the multi-arch Docker image to GHCR (`v1.12.0` and `latest`).
