### PR TITLE
fix(draw): fade the idle shine out on hover instead of cutting it

### DIFF
--- a/public/css/cards.css
+++ b/public/css/cards.css
@@ -697,7 +697,13 @@
   transform: translateX(-180%) skewX(-14deg);
   animation: shine-sweep 6.5s ease-in-out infinite;
   will-change: transform;
+  opacity: 1;
+  transition: opacity 0.35s ease;
 }
+/* During pointer or gyro interaction the holographic layer takes over
+   (holo-on is set on the first tilt frame for every card, foil or not);
+   fade the idle streak out instead of cutting it mid-sweep. */
+.card-front.idle-shine.holo-on::before { opacity: 0; }
 @keyframes shine-sweep {
   0%   { transform: translateX(-180%) skewX(-14deg); }
   48%  { transform: translateX(260%) skewX(-14deg); }

--- a/public/js/features/deck/draw.js
+++ b/public/js/features/deck/draw.js
@@ -250,8 +250,9 @@ function applyTilt(rx, ry) {
   const py = 50 - (clampedRx / MAX) * 40;
   front.style.setProperty('--px', px.toFixed(1));
   front.style.setProperty('--py', py.toFixed(1));
+  // holo-on also fades the idle shine out through CSS; removing the class
+  // here instead would cut the streak mid-sweep with no transition.
   front.classList.add('holo-on');
-  front.classList.remove('idle-shine');
 }
 
 function smoothReturnToCenter() {

--- a/public/sw.js
+++ b/public/sw.js
@@ -4,7 +4,7 @@
 //   * /api/cards: stale-while-revalidate (allows offline viewing)
 //   * all other /api/*: network only, never cached (auth-sensitive)
 
-const VERSION = 'couplecards-v53';
+const VERSION = 'couplecards-v54';
 const SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
The tilt handler removed the `idle-shine` class on the first pointer move, so a sweep in progress disappeared in a single frame; the new streak is prominent enough to make that cut obvious. The class now stays on and the `holo-on` interaction state (set on the first tilt frame, foil or not) fades the streak with a 0.35 s opacity transition, both when the pointer arrives and when it leaves.

No CHANGELOG entry: this fixes behavior that is itself still in [Unreleased], so the release notes keep describing the final behavior.

## Expected behaviors

- Moving the pointer onto a revealed card fades the golden streak out smoothly while the holographic tilt takes over; leaving the card fades it back in.
- Under "reduce motion" nothing changes: no shine, no tilt.