### PR TITLE
fix(deck): remove near-duplicate cards and drop British spellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - The revealed card's idle shine now sweeps the whole face as a soft golden glint, and the card sits visually centered between the title and the action buttons.
+- The bad-singing card "Lyrical massacre" is reworked into "Lip-sync battle" so it no longer tells the same joke as the living-room karaoke card, and the English deck drops its last British spellings for US English.
+
+### Removed
+
+- Three near-duplicate cards leave the seed deck: the second car-in-the-woods escapade, the generic outdoor-thrill card, and the second racy photo shoot. Instances that already seeded keep them until an admin applies a "Full mirror" deck sync.
 
 ### Fixed
 

--- a/data/cards.de.json
+++ b/data/cards.de.json
@@ -47,9 +47,9 @@
     {
       "id": "home-007",
       "pile": "home",
-      "emoji": "microphone",
-      "title": "Lyrisches Massaker",
-      "description": "Falsch singen mit Diven-Arroganz. Der Schlechteste schuldet eine erzwungene Umarmung."
+      "emoji": "musical-notes",
+      "title": "Playback-Battle",
+      "description": "Mime deine Hymne mit Rockstar-Inbrunst. Wer am wenigsten überzeugt, faltet die Wäsche."
     },
     {
       "id": "home-008",
@@ -264,14 +264,6 @@
       "emoji": "shushing-face",
       "title": "Unreine Geständnisse",
       "description": "Wahrheit oder Pflicht ohne Tabus. Ablehnen ist heute Abend keine Option."
-    },
-    {
-      "id": "home-039",
-      "pile": "home",
-      "foil": true,
-      "emoji": "camera-with-flash",
-      "title": "Sehr privates Studio",
-      "description": "Gewagte visuelle Erinnerungen schaffen. Hoffen wir, dein Cloud-Speicher ist sicher."
     },
     {
       "id": "home-040",
@@ -721,14 +713,6 @@
       "description": "Zufallscafé, wir kommen getrennt an. Bagger mich an wie ein reiches, leichtes Ziel."
     },
     {
-      "id": "out-033",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Waldpause",
-      "description": "Auto im Wald, Sitze gekippt. Die Scheiben beschlagen rein zufällig."
-    },
-    {
       "id": "out-034",
       "pile": "outdoor",
       "foil": true,
@@ -759,14 +743,6 @@
       "emoji": "zipper-mouth-face",
       "title": "Geheimkommando",
       "description": "Ohne Unterwäsche ausgehen. Das Geheimnis macht jeden Blick brennend."
-    },
-    {
-      "id": "out-038",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Öffentlicher Nervenkitzel",
-      "description": "Eine versteckte Ecke draußen finden. Risiko ist das beste Aphrodisiakum."
     },
     {
       "id": "out-039",

--- a/data/cards.en.json
+++ b/data/cards.en.json
@@ -47,9 +47,9 @@
     {
       "id": "home-007",
       "pile": "home",
-      "emoji": "microphone",
-      "title": "Lyrical massacre",
-      "description": "Sing out of tune with diva arrogance. Worst performer owes an unwanted hug."
+      "emoji": "musical-notes",
+      "title": "Lip-sync battle",
+      "description": "Mime your anthem with rock-star fervor. The least convincing folds the laundry."
     },
     {
       "id": "home-008",
@@ -199,8 +199,8 @@
       "id": "home-030",
       "pile": "home",
       "emoji": "takeout-box",
-      "title": "Distant flavours",
-      "description": "Exotic meal ordered at random. If we choke, we travelled for real."
+      "title": "Distant flavors",
+      "description": "Exotic meal ordered at random. If we choke, we traveled for real."
     },
     {
       "id": "home-031",
@@ -224,7 +224,7 @@
       "foil": true,
       "emoji": "kiss-mark",
       "title": "Temporary tattoos",
-      "description": "Your body is my canvas. I draw my desires, you interpret them with fervour."
+      "description": "Your body is my canvas. I draw my desires, you interpret them with fervor."
     },
     {
       "id": "home-034",
@@ -264,14 +264,6 @@
       "emoji": "shushing-face",
       "title": "Impure confessions",
       "description": "Truth or dare, no taboos. Refusing is clearly not an option tonight."
-    },
-    {
-      "id": "home-039",
-      "pile": "home",
-      "foil": true,
-      "emoji": "camera-with-flash",
-      "title": "A very private studio",
-      "description": "Making risqué visual memories. Let's hope your cloud is encrypted."
     },
     {
       "id": "home-040",
@@ -337,7 +329,7 @@
       "foil": true,
       "emoji": "graduation-cap",
       "title": "Private lesson",
-      "description": "Classic role-play. Let's see who deserves punishment or high honours."
+      "description": "Classic role-play. Let's see who deserves punishment or high honors."
     },
     {
       "id": "home-049",
@@ -366,7 +358,7 @@
       "id": "home-052",
       "pile": "home",
       "emoji": "balance-scale",
-      "title": "Final judgement",
+      "title": "Final judgment",
       "description": "Dubious purity test found online. A chance to mock your past with humor."
     },
     {
@@ -381,7 +373,7 @@
       "pile": "home",
       "emoji": "red-question-mark",
       "title": "School of laughter",
-      "description": "Primary-school-level quiz. Your ego may take a fatal hit."
+      "description": "Grade-school quiz. Your ego may take a fatal hit."
     },
     {
       "id": "home-055",
@@ -409,7 +401,7 @@
       "pile": "home",
       "emoji": "performing-arts",
       "title": "Sunday Shakespeare",
-      "description": "Act out an improbable scene, deadpan. First to break has lost their honour."
+      "description": "Act out an improbable scene, deadpan. First to break has lost their honor."
     },
     {
       "id": "home-059",
@@ -451,7 +443,7 @@
       "pile": "home",
       "emoji": "crystal-ball",
       "title": "Botched astrology",
-      "description": "Read today's horoscope, po-faced. Tear every prediction apart without mercy."
+      "description": "Read today's horoscope, straight-faced. Tear every prediction apart without mercy."
     },
     {
       "id": "home-065",
@@ -507,7 +499,7 @@
       "pile": "outdoor",
       "emoji": "popcorn",
       "title": "Cinema and contempt",
-      "description": "Film picked at random. The real pleasure is demolishing it afterwards like bitter critics."
+      "description": "Film picked at random. The real pleasure is demolishing it afterward like bitter critics."
     },
     {
       "id": "out-003",
@@ -591,7 +583,7 @@
       "id": "out-014",
       "pile": "outdoor",
       "emoji": "hot-springs",
-      "title": "Tropical vapours",
+      "title": "Tropical vapors",
       "description": "Spa and humid heat. Leave floppy, with a pressing urge to end up in bed."
     },
     {
@@ -721,14 +713,6 @@
       "description": "Random café, arrive separately. Hit on me like I'm a rich, easy target."
     },
     {
-      "id": "out-033",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Wild detour",
-      "description": "Car parked in a forest, seats reclined. Windows fog up by accident."
-    },
-    {
       "id": "out-034",
       "pile": "outdoor",
       "foil": true,
@@ -761,14 +745,6 @@
       "description": "Go out without underwear. The secret makes every glance burn."
     },
     {
-      "id": "out-038",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Public thrill",
-      "description": "Find a discreet corner out in the open. Risk is the best stimulant."
-    },
-    {
       "id": "out-039",
       "pile": "outdoor",
       "emoji": "axe",
@@ -780,7 +756,7 @@
       "pile": "outdoor",
       "emoji": "books",
       "title": "Suggestive title",
-      "description": "At the bookshop, pick a book whose title sums up what you want to do to me tonight."
+      "description": "At the bookstore, pick a book whose title sums up what you want to do to me tonight."
     },
     {
       "id": "out-041",
@@ -895,7 +871,7 @@
       "pile": "outdoor",
       "emoji": "hiking-boot",
       "title": "Symbolic hike",
-      "description": "Walk 2 km to justify the massive drinks afterwards. The effort is purely psychological."
+      "description": "Walk 2 km to justify the massive drinks afterward. The effort is purely psychological."
     },
     {
       "id": "out-058",
@@ -978,7 +954,7 @@
       "id": "out-069",
       "pile": "outdoor",
       "emoji": "person-rowing-boat",
-      "title": "Synchronised pedalo",
+      "title": "Synchronized pedalo",
       "description": "Pedal as a duo with zero coordination. The only real risk is public humiliation."
     },
     {

--- a/data/cards.es.json
+++ b/data/cards.es.json
@@ -47,9 +47,9 @@
     {
       "id": "home-007",
       "pile": "home",
-      "emoji": "microphone",
-      "title": "Masacre lírica",
-      "description": "Canten desafinando con arrogancia de diva. El peor debe un abrazo impuesto."
+      "emoji": "musical-notes",
+      "title": "Batalla de playback",
+      "description": "Imita tu himno con fervor de estrella de rock. El menos convincente dobla la ropa."
     },
     {
       "id": "home-008",
@@ -264,14 +264,6 @@
       "emoji": "shushing-face",
       "title": "Confesiones impuras",
       "description": "Verdad o reto sin tabúes. Rajarse esta noche no es opción."
-    },
-    {
-      "id": "home-039",
-      "pile": "home",
-      "foil": true,
-      "emoji": "camera-with-flash",
-      "title": "Estudio muy privado",
-      "description": "Crear recuerdos visuales atrevidos. Esperemos que tu nube esté bien protegida."
     },
     {
       "id": "home-040",
@@ -721,14 +713,6 @@
       "description": "Café al azar, llegamos por separado. Lígame como si fuese una presa rica y fácil."
     },
     {
-      "id": "out-033",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Parada salvaje",
-      "description": "Coche en el bosque, asientos reclinados. Las ventanillas se empañan por accidente."
-    },
-    {
       "id": "out-034",
       "pile": "outdoor",
       "foil": true,
@@ -759,14 +743,6 @@
       "emoji": "zipper-mouth-face",
       "title": "Comando secreto",
       "description": "Salir sin ropa interior. El secreto hace que cada mirada queme."
-    },
-    {
-      "id": "out-038",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Escalofrío público",
-      "description": "Encontrar un rincón discreto al aire libre. El riesgo es el mejor afrodisíaco."
     },
     {
       "id": "out-039",

--- a/data/cards.fr.json
+++ b/data/cards.fr.json
@@ -47,9 +47,9 @@
     {
       "id": "home-007",
       "pile": "home",
-      "emoji": "microphone",
-      "title": "Massacre lyrique",
-      "description": "Chantez faux avec l'arrogance d'une diva. Le plus mauvais gagne un câlin imposé."
+      "emoji": "musical-notes",
+      "title": "Battle de playback",
+      "description": "Mime ton tube culte avec une ferveur de rock star. Le moins crédible plie le linge."
     },
     {
       "id": "home-008",
@@ -264,14 +264,6 @@
       "emoji": "shushing-face",
       "title": "Confessions impures",
       "description": "Action ou vérité sans tabou. Refuser n'est clairement pas une option ce soir."
-    },
-    {
-      "id": "home-039",
-      "pile": "home",
-      "foil": true,
-      "emoji": "camera-with-flash",
-      "title": "Studio très privé",
-      "description": "Créer des souvenirs visuels osés. Espérons que ton cloud est protégé."
     },
     {
       "id": "home-040",
@@ -721,14 +713,6 @@
       "description": "Café au hasard, on arrive séparément. Drague-moi comme une cible riche et facile."
     },
     {
-      "id": "out-033",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Pause sauvage",
-      "description": "Voiture en forêt, sièges inclinés. Les vitres se brouillent par accident."
-    },
-    {
       "id": "out-034",
       "pile": "outdoor",
       "foil": true,
@@ -759,14 +743,6 @@
       "emoji": "zipper-mouth-face",
       "title": "Commando secret",
       "description": "Sortir sans sous-vêtements. Ce secret rend chaque regard brûlant."
-    },
-    {
-      "id": "out-038",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Frisson public",
-      "description": "Trouver un coin discret en plein air. Le risque est le meilleur des excitants."
     },
     {
       "id": "out-039",

--- a/data/cards.it.json
+++ b/data/cards.it.json
@@ -47,9 +47,9 @@
     {
       "id": "home-007",
       "pile": "home",
-      "emoji": "microphone",
-      "title": "Massacro lirico",
-      "description": "Cantate stonati con arroganza da diva. Il peggiore deve un abbraccio non richiesto."
+      "emoji": "musical-notes",
+      "title": "Battaglia di playback",
+      "description": "Mima il tuo tormentone con foga da rockstar. Il meno credibile piega il bucato."
     },
     {
       "id": "home-008",
@@ -264,14 +264,6 @@
       "emoji": "shushing-face",
       "title": "Confessioni impure",
       "description": "Obbligo o verità senza tabù. Rifiutare stasera non è proprio un'opzione."
-    },
-    {
-      "id": "home-039",
-      "pile": "home",
-      "foil": true,
-      "emoji": "camera-with-flash",
-      "title": "Studio molto privato",
-      "description": "Creare ricordi visivi audaci. Speriamo che il tuo cloud sia ben protetto."
     },
     {
       "id": "home-040",
@@ -721,14 +713,6 @@
       "description": "Caffè a caso, si arriva separati. Rimorchiami come un bersaglio ricco e facile."
     },
     {
-      "id": "out-033",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Sosta selvaggia",
-      "description": "Auto nel bosco, sedili reclinati. I vetri si appannano per caso."
-    },
-    {
       "id": "out-034",
       "pile": "outdoor",
       "foil": true,
@@ -759,14 +743,6 @@
       "emoji": "zipper-mouth-face",
       "title": "Commando segreto",
       "description": "Uscire senza biancheria intima. Il segreto rende ogni sguardo bollente."
-    },
-    {
-      "id": "out-038",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Brivido pubblico",
-      "description": "Trovare un angolo discreto all'aperto. Il rischio è il miglior eccitante."
     },
     {
       "id": "out-039",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,7 +84,7 @@ The SPA router lives in `public/js/core/router.js` and is roughly seventy lines 
 
 ## Card draw
 
-`drawRandom(pile, recentIds)` in `public/js/core/sync.js` picks the next card for a pile. It first removes the user's banned cards (`availableCards`), then excludes the most recently drawn ids in that pile (`CONFIG.recentExclude`, three by default) so the same card does not come back two draws in a row. From the remaining pool it does a weighted random pick: standard cards weigh `1.0`, foil cards weigh `FOIL_WEIGHT = 0.3`. The constant lives at the top of `sync.js` and exists to keep the appearance rate of foil cards (the rare, explicitly sexual variant) low even when their share of the deck is non-trivial. With the current FR deck (28 foil out of 142), the effective foil draw rate is around 9.7% on the home pile and 4.4% on the outdoor pile, well below what the raw counts would suggest.
+`drawRandom(pile, recentIds)` in `public/js/core/sync.js` picks the next card for a pile. It first removes the user's banned cards (`availableCards`), then excludes the most recently drawn ids in that pile (`CONFIG.recentExclude`, three by default) so the same card does not come back two draws in a row. From the remaining pool it does a weighted random pick: standard cards weigh `1.0`, foil cards weigh `FOIL_WEIGHT = 0.3`. The constant lives at the top of `sync.js` and exists to keep the appearance rate of foil cards (the rare, explicitly sexual variant) low even when their share of the deck is non-trivial. With the current FR deck (25 foil out of 139), the effective foil draw rate is around 9.3% on the home pile and 3.6% on the outdoor pile, well below what the raw counts would suggest.
 
 ## Collection screen
 


### PR DESCRIPTION
## Summary

Deck review pass across all five locales (fr, en, de, it, es).

- Remove three near-duplicate foil cards: out-033 "Pause sauvage" (duplicate of out-050 "Banquette arrière"), out-038 "Frisson public" (overlapped out-010 "Évasion sylvestre"), and home-039 "Studio très privé" (duplicate of home-011 "Preuves compromettantes").
- Rework home-007 from a second bad-singing card into a lip-sync battle so it no longer tells the same joke as home-062 "Karaoké de salon"; its emoji moves from `microphone` to `musical-notes`.
- Replace the remaining British spellings in `cards.en.json` with US English (flavours, fervour, honours, judgement, vapours, synchronised, afterwards, bookshop, po-faced, primary school).
- Update the foil draw-rate figures in `docs/architecture.md` (25 foil out of 139, around 9.3% home and 3.6% outdoor) and add the CHANGELOG entries.

## Expected behaviors

- Fresh installs seed 139 cards per locale; the id, pile, foil, and emoji fields stay identical across locales, so the boot-time seed validation passes.
- Existing instances keep the removed cards until an admin applies a "Full mirror" deck sync; an "Add and update" sync updates home-007 in place without deleting anything.
- No user-facing UI string, locale list, or API change.
