### PR TITLE
feat(deck): add eight new cards across both piles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - The revealed card's idle shine now sweeps the whole face as a soft golden glint, and the card sits visually centered between the title and the action buttons.
+- The bad-singing card "Lyrical massacre" is reworked into "Lip-sync battle" so it no longer tells the same joke as the living-room karaoke card, and the English deck drops its last British spellings for US English.
+
+### Removed
+
+- Three near-duplicate cards leave the seed deck: the second car-in-the-woods escapade, the generic outdoor-thrill card, and the second racy photo shoot. Instances that already seeded keep them until an admin applies a "Full mirror" deck sync.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - The History screen gains filter chips (pile, returned, banned) and a summary line with the total number of draws and bans.
 - The Collection gains two filters: "Banned" to find banned cards without scanning the grid, and "Undiscovered" to see what is left to find.
 - The admin Users tab can rename an account.
+- Eight new cards join the seed deck, four per pile with one foil each: improvised movie dubbing, absurd courtroom pleas, virtual vacation planning, and a desire lottery at home; coin-flip wandering, library giggle duels, ice skating, and a daytime hotel escapade outdoors. Three new emoji are bundled for them (desert island, ice skate, love hotel).
 
 ### Changed
 

--- a/data/cards.de.json
+++ b/data/cards.de.json
@@ -47,9 +47,9 @@
     {
       "id": "home-007",
       "pile": "home",
-      "emoji": "microphone",
-      "title": "Lyrisches Massaker",
-      "description": "Falsch singen mit Diven-Arroganz. Der Schlechteste schuldet eine erzwungene Umarmung."
+      "emoji": "musical-notes",
+      "title": "Playback-Battle",
+      "description": "Mime deine Hymne mit Rockstar-Inbrunst. Wer am wenigsten überzeugt, faltet die Wäsche."
     },
     {
       "id": "home-008",
@@ -264,14 +264,6 @@
       "emoji": "shushing-face",
       "title": "Unreine Geständnisse",
       "description": "Wahrheit oder Pflicht ohne Tabus. Ablehnen ist heute Abend keine Option."
-    },
-    {
-      "id": "home-039",
-      "pile": "home",
-      "foil": true,
-      "emoji": "camera-with-flash",
-      "title": "Sehr privates Studio",
-      "description": "Gewagte visuelle Erinnerungen schaffen. Hoffen wir, dein Cloud-Speicher ist sicher."
     },
     {
       "id": "home-040",
@@ -721,14 +713,6 @@
       "description": "Zufallscafé, wir kommen getrennt an. Bagger mich an wie ein reiches, leichtes Ziel."
     },
     {
-      "id": "out-033",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Waldpause",
-      "description": "Auto im Wald, Sitze gekippt. Die Scheiben beschlagen rein zufällig."
-    },
-    {
       "id": "out-034",
       "pile": "outdoor",
       "foil": true,
@@ -759,14 +743,6 @@
       "emoji": "zipper-mouth-face",
       "title": "Geheimkommando",
       "description": "Ohne Unterwäsche ausgehen. Das Geheimnis macht jeden Blick brennend."
-    },
-    {
-      "id": "out-038",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Öffentlicher Nervenkitzel",
-      "description": "Eine versteckte Ecke draußen finden. Risiko ist das beste Aphrodisiakum."
     },
     {
       "id": "out-039",

--- a/data/cards.de.json
+++ b/data/cards.de.json
@@ -488,6 +488,35 @@
       "description": "Jeder erzählt seine drei schlimmsten Witze. Der Unlustigste räumt ab."
     },
     {
+      "id": "home-071",
+      "pile": "home",
+      "emoji": "clapper-board",
+      "title": "Wilde Synchro",
+      "description": "Film auf stumm, wir improvisieren jeden Dialog. Das Drehbuch wird schnell unaussprechlich."
+    },
+    {
+      "id": "home-072",
+      "pile": "home",
+      "emoji": "balance-scale",
+      "title": "Absurdes Plädoyer",
+      "description": "Verteidige eine lächerliche Sache mit Anwaltsstrenge. Die Jury (ich) ist bestechlich."
+    },
+    {
+      "id": "home-073",
+      "pile": "home",
+      "emoji": "desert-island",
+      "title": "Virtueller Urlaub",
+      "description": "Zufälliges Street View, imaginäres Budget. Wir planen die Reise, die nie stattfindet."
+    },
+    {
+      "id": "home-074",
+      "pile": "home",
+      "foil": true,
+      "emoji": "love-letter",
+      "title": "Lotterie der Gelüste",
+      "description": "Jeder schreibt drei unaussprechliche Gelüste auf, eins wird gezogen. Sofort fällig."
+    },
+    {
       "id": "out-001",
       "pile": "outdoor",
       "emoji": "spaghetti",
@@ -998,6 +1027,35 @@
       "emoji": "selfie",
       "title": "Influencer für einen Tag",
       "description": "Lächerliche Posen in der Stadt für zehn Story-Fotos. Versteinerte Miene und Unschärfe Pflicht."
+    },
+    {
+      "id": "out-076",
+      "pile": "outdoor",
+      "emoji": "coin",
+      "title": "Münzwurf-Wanderung",
+      "description": "An jeder Kreuzung entscheidet die Münze. Sackgassen zählen als Sehenswürdigkeit."
+    },
+    {
+      "id": "out-077",
+      "pile": "outdoor",
+      "emoji": "shushing-face",
+      "title": "Verbotenes Kichern",
+      "description": "In der Bibliothek den anderen lautlos zum Lachen bringen. Rauswurf gilt als Sieg."
+    },
+    {
+      "id": "out-078",
+      "pile": "outdoor",
+      "emoji": "ice-skate",
+      "title": "Bambi auf Eis",
+      "description": "Eisbahn zu zweit, Knöchel optional. Wer zuerst fällt, zahlt den Kakao."
+    },
+    {
+      "id": "out-079",
+      "pile": "outdoor",
+      "foil": true,
+      "emoji": "love-hotel",
+      "title": "Affäre am Nachmittag",
+      "description": "Hotelzimmer am helllichten Tag, falsche Namen an der Rezeption. Zwei Stunden, null Reue."
     }
   ]
 }

--- a/data/cards.en.json
+++ b/data/cards.en.json
@@ -47,9 +47,9 @@
     {
       "id": "home-007",
       "pile": "home",
-      "emoji": "microphone",
-      "title": "Lyrical massacre",
-      "description": "Sing out of tune with diva arrogance. Worst performer owes an unwanted hug."
+      "emoji": "musical-notes",
+      "title": "Lip-sync battle",
+      "description": "Mime your anthem with rock-star fervor. The least convincing folds the laundry."
     },
     {
       "id": "home-008",
@@ -199,8 +199,8 @@
       "id": "home-030",
       "pile": "home",
       "emoji": "takeout-box",
-      "title": "Distant flavours",
-      "description": "Exotic meal ordered at random. If we choke, we travelled for real."
+      "title": "Distant flavors",
+      "description": "Exotic meal ordered at random. If we choke, we traveled for real."
     },
     {
       "id": "home-031",
@@ -224,7 +224,7 @@
       "foil": true,
       "emoji": "kiss-mark",
       "title": "Temporary tattoos",
-      "description": "Your body is my canvas. I draw my desires, you interpret them with fervour."
+      "description": "Your body is my canvas. I draw my desires, you interpret them with fervor."
     },
     {
       "id": "home-034",
@@ -264,14 +264,6 @@
       "emoji": "shushing-face",
       "title": "Impure confessions",
       "description": "Truth or dare, no taboos. Refusing is clearly not an option tonight."
-    },
-    {
-      "id": "home-039",
-      "pile": "home",
-      "foil": true,
-      "emoji": "camera-with-flash",
-      "title": "A very private studio",
-      "description": "Making risqué visual memories. Let's hope your cloud is encrypted."
     },
     {
       "id": "home-040",
@@ -337,7 +329,7 @@
       "foil": true,
       "emoji": "graduation-cap",
       "title": "Private lesson",
-      "description": "Classic role-play. Let's see who deserves punishment or high honours."
+      "description": "Classic role-play. Let's see who deserves punishment or high honors."
     },
     {
       "id": "home-049",
@@ -366,7 +358,7 @@
       "id": "home-052",
       "pile": "home",
       "emoji": "balance-scale",
-      "title": "Final judgement",
+      "title": "Final judgment",
       "description": "Dubious purity test found online. A chance to mock your past with humor."
     },
     {
@@ -381,7 +373,7 @@
       "pile": "home",
       "emoji": "red-question-mark",
       "title": "School of laughter",
-      "description": "Primary-school-level quiz. Your ego may take a fatal hit."
+      "description": "Grade-school quiz. Your ego may take a fatal hit."
     },
     {
       "id": "home-055",
@@ -409,7 +401,7 @@
       "pile": "home",
       "emoji": "performing-arts",
       "title": "Sunday Shakespeare",
-      "description": "Act out an improbable scene, deadpan. First to break has lost their honour."
+      "description": "Act out an improbable scene, deadpan. First to break has lost their honor."
     },
     {
       "id": "home-059",
@@ -451,7 +443,7 @@
       "pile": "home",
       "emoji": "crystal-ball",
       "title": "Botched astrology",
-      "description": "Read today's horoscope, po-faced. Tear every prediction apart without mercy."
+      "description": "Read today's horoscope, straight-faced. Tear every prediction apart without mercy."
     },
     {
       "id": "home-065",
@@ -507,7 +499,7 @@
       "pile": "outdoor",
       "emoji": "popcorn",
       "title": "Cinema and contempt",
-      "description": "Film picked at random. The real pleasure is demolishing it afterwards like bitter critics."
+      "description": "Film picked at random. The real pleasure is demolishing it afterward like bitter critics."
     },
     {
       "id": "out-003",
@@ -591,7 +583,7 @@
       "id": "out-014",
       "pile": "outdoor",
       "emoji": "hot-springs",
-      "title": "Tropical vapours",
+      "title": "Tropical vapors",
       "description": "Spa and humid heat. Leave floppy, with a pressing urge to end up in bed."
     },
     {
@@ -721,14 +713,6 @@
       "description": "Random café, arrive separately. Hit on me like I'm a rich, easy target."
     },
     {
-      "id": "out-033",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Wild detour",
-      "description": "Car parked in a forest, seats reclined. Windows fog up by accident."
-    },
-    {
       "id": "out-034",
       "pile": "outdoor",
       "foil": true,
@@ -761,14 +745,6 @@
       "description": "Go out without underwear. The secret makes every glance burn."
     },
     {
-      "id": "out-038",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Public thrill",
-      "description": "Find a discreet corner out in the open. Risk is the best stimulant."
-    },
-    {
       "id": "out-039",
       "pile": "outdoor",
       "emoji": "axe",
@@ -780,7 +756,7 @@
       "pile": "outdoor",
       "emoji": "books",
       "title": "Suggestive title",
-      "description": "At the bookshop, pick a book whose title sums up what you want to do to me tonight."
+      "description": "At the bookstore, pick a book whose title sums up what you want to do to me tonight."
     },
     {
       "id": "out-041",
@@ -895,7 +871,7 @@
       "pile": "outdoor",
       "emoji": "hiking-boot",
       "title": "Symbolic hike",
-      "description": "Walk 2 km to justify the massive drinks afterwards. The effort is purely psychological."
+      "description": "Walk 2 km to justify the massive drinks afterward. The effort is purely psychological."
     },
     {
       "id": "out-058",
@@ -978,7 +954,7 @@
       "id": "out-069",
       "pile": "outdoor",
       "emoji": "person-rowing-boat",
-      "title": "Synchronised pedalo",
+      "title": "Synchronized pedalo",
       "description": "Pedal as a duo with zero coordination. The only real risk is public humiliation."
     },
     {

--- a/data/cards.en.json
+++ b/data/cards.en.json
@@ -488,6 +488,35 @@
       "description": "Each one tells their 3 worst jokes. The least funny clears the table."
     },
     {
+      "id": "home-071",
+      "pile": "home",
+      "emoji": "clapper-board",
+      "title": "Rogue dubbing",
+      "description": "Movie on mute, we improvise every line. The plot goes off the rails fast."
+    },
+    {
+      "id": "home-072",
+      "pile": "home",
+      "emoji": "balance-scale",
+      "title": "Absurd closing argument",
+      "description": "Defend a ridiculous cause with lawyerly rigor. The jury (me) accepts bribes."
+    },
+    {
+      "id": "home-073",
+      "pile": "home",
+      "emoji": "desert-island",
+      "title": "Virtual vacation",
+      "description": "Random Street View, imaginary budget. Plan the trip we will never take."
+    },
+    {
+      "id": "home-074",
+      "pile": "home",
+      "foil": true,
+      "emoji": "love-letter",
+      "title": "Desire lottery",
+      "description": "We each write three unspeakable desires and draw one. Carried out on the spot."
+    },
+    {
       "id": "out-001",
       "pile": "outdoor",
       "emoji": "spaghetti",
@@ -998,6 +1027,35 @@
       "emoji": "selfie",
       "title": "Influencer for a day",
       "description": "10 ridiculous story-style poses around town. Stone-faced, artistic blur required."
+    },
+    {
+      "id": "out-076",
+      "pile": "outdoor",
+      "emoji": "coin",
+      "title": "Coin-flip wandering",
+      "description": "At every corner the coin decides. Dead ends count as scenery."
+    },
+    {
+      "id": "out-077",
+      "pile": "outdoor",
+      "emoji": "shushing-face",
+      "title": "Forbidden giggles",
+      "description": "At the library, crack each other up in total silence. Eviction counts as a win."
+    },
+    {
+      "id": "out-078",
+      "pile": "outdoor",
+      "emoji": "ice-skate",
+      "title": "Bambi on ice",
+      "description": "Ice rink as a duo, ankles optional. First one down buys the hot chocolate."
+    },
+    {
+      "id": "out-079",
+      "pile": "outdoor",
+      "foil": true,
+      "emoji": "love-hotel",
+      "title": "Afternoon affair",
+      "description": "Daytime hotel room, fake names at the desk. Two hours, zero remorse."
     }
   ]
 }

--- a/data/cards.es.json
+++ b/data/cards.es.json
@@ -47,9 +47,9 @@
     {
       "id": "home-007",
       "pile": "home",
-      "emoji": "microphone",
-      "title": "Masacre lírica",
-      "description": "Canten desafinando con arrogancia de diva. El peor debe un abrazo impuesto."
+      "emoji": "musical-notes",
+      "title": "Batalla de playback",
+      "description": "Imita tu himno con fervor de estrella de rock. El menos convincente dobla la ropa."
     },
     {
       "id": "home-008",
@@ -264,14 +264,6 @@
       "emoji": "shushing-face",
       "title": "Confesiones impuras",
       "description": "Verdad o reto sin tabúes. Rajarse esta noche no es opción."
-    },
-    {
-      "id": "home-039",
-      "pile": "home",
-      "foil": true,
-      "emoji": "camera-with-flash",
-      "title": "Estudio muy privado",
-      "description": "Crear recuerdos visuales atrevidos. Esperemos que tu nube esté bien protegida."
     },
     {
       "id": "home-040",
@@ -721,14 +713,6 @@
       "description": "Café al azar, llegamos por separado. Lígame como si fuese una presa rica y fácil."
     },
     {
-      "id": "out-033",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Parada salvaje",
-      "description": "Coche en el bosque, asientos reclinados. Las ventanillas se empañan por accidente."
-    },
-    {
       "id": "out-034",
       "pile": "outdoor",
       "foil": true,
@@ -759,14 +743,6 @@
       "emoji": "zipper-mouth-face",
       "title": "Comando secreto",
       "description": "Salir sin ropa interior. El secreto hace que cada mirada queme."
-    },
-    {
-      "id": "out-038",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Escalofrío público",
-      "description": "Encontrar un rincón discreto al aire libre. El riesgo es el mejor afrodisíaco."
     },
     {
       "id": "out-039",

--- a/data/cards.es.json
+++ b/data/cards.es.json
@@ -488,6 +488,35 @@
       "description": "Cada uno cuenta sus 3 peores chistes. El menos gracioso recoge la mesa."
     },
     {
+      "id": "home-071",
+      "pile": "home",
+      "emoji": "clapper-board",
+      "title": "Doblaje salvaje",
+      "description": "Peli en silencio, improvisamos todos los diálogos. El guion degenera enseguida."
+    },
+    {
+      "id": "home-072",
+      "pile": "home",
+      "emoji": "balance-scale",
+      "title": "Alegato absurdo",
+      "description": "Defiende una causa ridícula con rigor de abogado. El jurado (yo) acepta sobornos."
+    },
+    {
+      "id": "home-073",
+      "pile": "home",
+      "emoji": "desert-island",
+      "title": "Vacaciones virtuales",
+      "description": "Street View al azar y presupuesto imaginario. Planeamos el viaje que nunca haremos."
+    },
+    {
+      "id": "home-074",
+      "pile": "home",
+      "foil": true,
+      "emoji": "love-letter",
+      "title": "Lotería de deseos",
+      "description": "Cada uno escribe tres deseos inconfesables y se sortea uno. Ejecución inmediata."
+    },
+    {
       "id": "out-001",
       "pile": "outdoor",
       "emoji": "spaghetti",
@@ -998,6 +1027,35 @@
       "emoji": "selfie",
       "title": "Influencer por un día",
       "description": "Poses ridículas por la ciudad para 10 fotos tipo story. Cara de palo y desenfoque artístico."
+    },
+    {
+      "id": "out-076",
+      "pile": "outdoor",
+      "emoji": "coin",
+      "title": "Rumbo a cara o cruz",
+      "description": "En cada cruce decide la moneda. Los callejones sin salida cuentan como paisaje."
+    },
+    {
+      "id": "out-077",
+      "pile": "outdoor",
+      "emoji": "shushing-face",
+      "title": "Risas prohibidas",
+      "description": "En la biblioteca, hacer reír al otro en silencio. La expulsión cuenta como victoria."
+    },
+    {
+      "id": "out-078",
+      "pile": "outdoor",
+      "emoji": "ice-skate",
+      "title": "Bambi sobre hielo",
+      "description": "Pista de hielo en pareja, tobillos opcionales. El primero en caer paga el chocolate."
+    },
+    {
+      "id": "out-079",
+      "pile": "outdoor",
+      "foil": true,
+      "emoji": "love-hotel",
+      "title": "Amantes de paso",
+      "description": "Hotel a plena luz del día, nombres falsos en recepción. Dos horas y cero remordimientos."
     }
   ]
 }

--- a/data/cards.fr.json
+++ b/data/cards.fr.json
@@ -488,6 +488,35 @@
       "description": "Chacun raconte ses 3 pires blagues. Le moins drôle débarrasse."
     },
     {
+      "id": "home-071",
+      "pile": "home",
+      "emoji": "clapper-board",
+      "title": "Doublage sauvage",
+      "description": "Film en muet, on improvise tous les dialogues. Le scénario devient vite inavouable."
+    },
+    {
+      "id": "home-072",
+      "pile": "home",
+      "emoji": "balance-scale",
+      "title": "Plaidoirie absurde",
+      "description": "Défends une cause ridicule avec une rigueur d'avocat. Le jury (moi) est corrompu."
+    },
+    {
+      "id": "home-073",
+      "pile": "home",
+      "emoji": "desert-island",
+      "title": "Vacances virtuelles",
+      "description": "Street View au hasard et budget imaginaire. On planifie des vacances qu'on ne prendra jamais."
+    },
+    {
+      "id": "home-074",
+      "pile": "home",
+      "foil": true,
+      "emoji": "love-letter",
+      "title": "Loterie des envies",
+      "description": "Chacun écrit trois envies inavouables, on en tire une au sort. Exécution immédiate."
+    },
+    {
       "id": "out-001",
       "pile": "outdoor",
       "emoji": "spaghetti",
@@ -998,6 +1027,35 @@
       "emoji": "selfie",
       "title": "Influenceur d'un jour",
       "description": "Poses ridicules en ville pour 10 photos style story. Air pénétré et flou artistique exigés."
+    },
+    {
+      "id": "out-076",
+      "pile": "outdoor",
+      "emoji": "coin",
+      "title": "Errance à pile ou face",
+      "description": "À chaque carrefour, la pièce décide. On assume les impasses comme les points de vue."
+    },
+    {
+      "id": "out-077",
+      "pile": "outdoor",
+      "emoji": "shushing-face",
+      "title": "Fous rires interdits",
+      "description": "En bibliothèque, faire craquer l'autre sans un bruit. L'expulsion vaut victoire commune."
+    },
+    {
+      "id": "out-078",
+      "pile": "outdoor",
+      "emoji": "ice-skate",
+      "title": "Bambi sur glace",
+      "description": "Patinoire en duo, chevilles en option. Le premier au sol paie le chocolat chaud."
+    },
+    {
+      "id": "out-079",
+      "pile": "outdoor",
+      "foil": true,
+      "emoji": "love-hotel",
+      "title": "Amants de passage",
+      "description": "Hôtel en pleine journée et faux noms à l'accueil. Deux heures et zéro remords."
     }
   ]
 }

--- a/data/cards.fr.json
+++ b/data/cards.fr.json
@@ -47,9 +47,9 @@
     {
       "id": "home-007",
       "pile": "home",
-      "emoji": "microphone",
-      "title": "Massacre lyrique",
-      "description": "Chantez faux avec l'arrogance d'une diva. Le plus mauvais gagne un câlin imposé."
+      "emoji": "musical-notes",
+      "title": "Battle de playback",
+      "description": "Mime ton tube culte avec une ferveur de rock star. Le moins crédible plie le linge."
     },
     {
       "id": "home-008",
@@ -264,14 +264,6 @@
       "emoji": "shushing-face",
       "title": "Confessions impures",
       "description": "Action ou vérité sans tabou. Refuser n'est clairement pas une option ce soir."
-    },
-    {
-      "id": "home-039",
-      "pile": "home",
-      "foil": true,
-      "emoji": "camera-with-flash",
-      "title": "Studio très privé",
-      "description": "Créer des souvenirs visuels osés. Espérons que ton cloud est protégé."
     },
     {
       "id": "home-040",
@@ -721,14 +713,6 @@
       "description": "Café au hasard, on arrive séparément. Drague-moi comme une cible riche et facile."
     },
     {
-      "id": "out-033",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Pause sauvage",
-      "description": "Voiture en forêt, sièges inclinés. Les vitres se brouillent par accident."
-    },
-    {
       "id": "out-034",
       "pile": "outdoor",
       "foil": true,
@@ -759,14 +743,6 @@
       "emoji": "zipper-mouth-face",
       "title": "Commando secret",
       "description": "Sortir sans sous-vêtements. Ce secret rend chaque regard brûlant."
-    },
-    {
-      "id": "out-038",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Frisson public",
-      "description": "Trouver un coin discret en plein air. Le risque est le meilleur des excitants."
     },
     {
       "id": "out-039",

--- a/data/cards.it.json
+++ b/data/cards.it.json
@@ -47,9 +47,9 @@
     {
       "id": "home-007",
       "pile": "home",
-      "emoji": "microphone",
-      "title": "Massacro lirico",
-      "description": "Cantate stonati con arroganza da diva. Il peggiore deve un abbraccio non richiesto."
+      "emoji": "musical-notes",
+      "title": "Battaglia di playback",
+      "description": "Mima il tuo tormentone con foga da rockstar. Il meno credibile piega il bucato."
     },
     {
       "id": "home-008",
@@ -264,14 +264,6 @@
       "emoji": "shushing-face",
       "title": "Confessioni impure",
       "description": "Obbligo o verità senza tabù. Rifiutare stasera non è proprio un'opzione."
-    },
-    {
-      "id": "home-039",
-      "pile": "home",
-      "foil": true,
-      "emoji": "camera-with-flash",
-      "title": "Studio molto privato",
-      "description": "Creare ricordi visivi audaci. Speriamo che il tuo cloud sia ben protetto."
     },
     {
       "id": "home-040",
@@ -721,14 +713,6 @@
       "description": "Caffè a caso, si arriva separati. Rimorchiami come un bersaglio ricco e facile."
     },
     {
-      "id": "out-033",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Sosta selvaggia",
-      "description": "Auto nel bosco, sedili reclinati. I vetri si appannano per caso."
-    },
-    {
       "id": "out-034",
       "pile": "outdoor",
       "foil": true,
@@ -759,14 +743,6 @@
       "emoji": "zipper-mouth-face",
       "title": "Commando segreto",
       "description": "Uscire senza biancheria intima. Il segreto rende ogni sguardo bollente."
-    },
-    {
-      "id": "out-038",
-      "pile": "outdoor",
-      "foil": true,
-      "emoji": "deciduous-tree",
-      "title": "Brivido pubblico",
-      "description": "Trovare un angolo discreto all'aperto. Il rischio è il miglior eccitante."
     },
     {
       "id": "out-039",

--- a/data/cards.it.json
+++ b/data/cards.it.json
@@ -488,6 +488,35 @@
       "description": "Ognuno racconta le sue tre battute più scadenti. Il meno divertente sparecchia."
     },
     {
+      "id": "home-071",
+      "pile": "home",
+      "emoji": "clapper-board",
+      "title": "Doppiaggio selvaggio",
+      "description": "Film in muto, improvvisiamo tutti i dialoghi. La trama degenera in fretta."
+    },
+    {
+      "id": "home-072",
+      "pile": "home",
+      "emoji": "balance-scale",
+      "title": "Arringa assurda",
+      "description": "Difendi una causa ridicola con rigore da avvocato. La giuria (io) è corrotta."
+    },
+    {
+      "id": "home-073",
+      "pile": "home",
+      "emoji": "desert-island",
+      "title": "Vacanza virtuale",
+      "description": "Street View a caso e budget immaginario. Pianifichiamo il viaggio che non faremo mai."
+    },
+    {
+      "id": "home-074",
+      "pile": "home",
+      "foil": true,
+      "emoji": "love-letter",
+      "title": "Lotteria dei desideri",
+      "description": "Ognuno scrive tre desideri inconfessabili, se ne estrae uno. Esecuzione immediata."
+    },
+    {
       "id": "out-001",
       "pile": "outdoor",
       "emoji": "spaghetti",
@@ -998,6 +1027,35 @@
       "emoji": "selfie",
       "title": "Influencer per un giorno",
       "description": "Pose ridicole in città per dieci foto in stile story. Faccia di marmo e sfocatura artistica."
+    },
+    {
+      "id": "out-076",
+      "pile": "outdoor",
+      "emoji": "coin",
+      "title": "Vagare a testa o croce",
+      "description": "A ogni incrocio decide la moneta. I vicoli ciechi contano come panorama."
+    },
+    {
+      "id": "out-077",
+      "pile": "outdoor",
+      "emoji": "shushing-face",
+      "title": "Risate proibite",
+      "description": "In biblioteca, far crollare l'altro in silenzio. L'espulsione vale come vittoria."
+    },
+    {
+      "id": "out-078",
+      "pile": "outdoor",
+      "emoji": "ice-skate",
+      "title": "Bambi sul ghiaccio",
+      "description": "Pista di pattinaggio in coppia, caviglie facoltative. Chi cade per primo paga la cioccolata."
+    },
+    {
+      "id": "out-079",
+      "pile": "outdoor",
+      "foil": true,
+      "emoji": "love-hotel",
+      "title": "Amanti di passaggio",
+      "description": "Camera d'albergo in pieno giorno, nomi falsi alla reception. Due ore e zero rimorsi."
     }
   ]
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,7 +84,7 @@ The SPA router lives in `public/js/core/router.js` and is roughly seventy lines 
 
 ## Card draw
 
-`drawRandom(pile, recentIds)` in `public/js/core/sync.js` picks the next card for a pile. It first removes the user's banned cards (`availableCards`), then excludes the most recently drawn ids in that pile (`CONFIG.recentExclude`, three by default) so the same card does not come back two draws in a row. From the remaining pool it does a weighted random pick: standard cards weigh `1.0`, foil cards weigh `FOIL_WEIGHT = 0.3`. The constant lives at the top of `sync.js` and exists to keep the appearance rate of foil cards (the rare, explicitly sexual variant) low even when their share of the deck is non-trivial. With the current FR deck (28 foil out of 142), the effective foil draw rate is around 9.7% on the home pile and 4.4% on the outdoor pile, well below what the raw counts would suggest.
+`drawRandom(pile, recentIds)` in `public/js/core/sync.js` picks the next card for a pile. It first removes the user's banned cards (`availableCards`), then excludes the most recently drawn ids in that pile (`CONFIG.recentExclude`, three by default) so the same card does not come back two draws in a row. From the remaining pool it does a weighted random pick: standard cards weigh `1.0`, foil cards weigh `FOIL_WEIGHT = 0.3`. The constant lives at the top of `sync.js` and exists to keep the appearance rate of foil cards (the rare, explicitly sexual variant) low even when their share of the deck is non-trivial. With the current FR deck (25 foil out of 139), the effective foil draw rate is around 9.3% on the home pile and 3.6% on the outdoor pile, well below what the raw counts would suggest.
 
 ## Collection screen
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,7 +84,7 @@ The SPA router lives in `public/js/core/router.js` and is roughly seventy lines 
 
 ## Card draw
 
-`drawRandom(pile, recentIds)` in `public/js/core/sync.js` picks the next card for a pile. It first removes the user's banned cards (`availableCards`), then excludes the most recently drawn ids in that pile (`CONFIG.recentExclude`, three by default) so the same card does not come back two draws in a row. From the remaining pool it does a weighted random pick: standard cards weigh `1.0`, foil cards weigh `FOIL_WEIGHT = 0.3`. The constant lives at the top of `sync.js` and exists to keep the appearance rate of foil cards (the rare, explicitly sexual variant) low even when their share of the deck is non-trivial. With the current FR deck (25 foil out of 139), the effective foil draw rate is around 9.3% on the home pile and 3.6% on the outdoor pile, well below what the raw counts would suggest.
+`drawRandom(pile, recentIds)` in `public/js/core/sync.js` picks the next card for a pile. It first removes the user's banned cards (`availableCards`), then excludes the most recently drawn ids in that pile (`CONFIG.recentExclude`, three by default) so the same card does not come back two draws in a row. From the remaining pool it does a weighted random pick: standard cards weigh `1.0`, foil cards weigh `FOIL_WEIGHT = 0.3`. The constant lives at the top of `sync.js` and exists to keep the appearance rate of foil cards (the rare, explicitly sexual variant) low even when their share of the deck is non-trivial. With the current FR deck (27 foil out of 147), the effective foil draw rate is around 9.2% on the home pile and 3.9% on the outdoor pile, well below what the raw counts would suggest.
 
 ## Collection screen
 

--- a/public/icons/emoji/desert-island.svg
+++ b/public/icons/emoji/desert-island.svg
@@ -1,0 +1,292 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18.465 8.35986H14.515C14.225 8.35986 13.995 8.58986 13.995 8.87986V25.9599C13.995 26.2499 14.225 26.4799 14.515 26.4799H18.465C18.755 26.4799 18.985 26.2499 18.985 25.9599V8.88986C18.985 8.59986 18.755 8.35986 18.465 8.35986Z" fill="url(#paint0_linear_18_5248)"/>
+<path d="M18.465 8.35986H14.515C14.225 8.35986 13.995 8.58986 13.995 8.87986V25.9599C13.995 26.2499 14.225 26.4799 14.515 26.4799H18.465C18.755 26.4799 18.985 26.2499 18.985 25.9599V8.88986C18.985 8.59986 18.755 8.35986 18.465 8.35986Z" fill="url(#paint1_linear_18_5248)"/>
+<path d="M18.465 8.35986H14.515C14.225 8.35986 13.995 8.58986 13.995 8.87986V25.9599C13.995 26.2499 14.225 26.4799 14.515 26.4799H18.465C18.755 26.4799 18.985 26.2499 18.985 25.9599V8.88986C18.985 8.59986 18.755 8.35986 18.465 8.35986Z" fill="url(#paint2_radial_18_5248)"/>
+<path d="M18.465 8.35986H14.515C14.225 8.35986 13.995 8.58986 13.995 8.87986V25.9599C13.995 26.2499 14.225 26.4799 14.515 26.4799H18.465C18.755 26.4799 18.985 26.2499 18.985 25.9599V8.88986C18.985 8.59986 18.755 8.35986 18.465 8.35986Z" fill="url(#paint3_radial_18_5248)"/>
+<path d="M18.465 8.35986H14.515C14.225 8.35986 13.995 8.58986 13.995 8.87986V25.9599C13.995 26.2499 14.225 26.4799 14.515 26.4799H18.465C18.755 26.4799 18.985 26.2499 18.985 25.9599V8.88986C18.985 8.59986 18.755 8.35986 18.465 8.35986Z" fill="url(#paint4_radial_18_5248)"/>
+<path d="M18.465 8.35986H14.515C14.225 8.35986 13.995 8.58986 13.995 8.87986V25.9599C13.995 26.2499 14.225 26.4799 14.515 26.4799H18.465C18.755 26.4799 18.985 26.2499 18.985 25.9599V8.88986C18.985 8.59986 18.755 8.35986 18.465 8.35986Z" fill="url(#paint5_radial_18_5248)"/>
+<path d="M18.465 8.35986H14.515C14.225 8.35986 13.995 8.58986 13.995 8.87986V25.9599C13.995 26.2499 14.225 26.4799 14.515 26.4799H18.465C18.755 26.4799 18.985 26.2499 18.985 25.9599V8.88986C18.985 8.59986 18.755 8.35986 18.465 8.35986Z" fill="url(#paint6_radial_18_5248)"/>
+<path d="M10.5449 8.5H15.5449C15.8211 8.5 16.0473 8.27541 16.0221 8.00042C15.7668 5.21126 13.3966 3 10.5449 3C7.87491 3 5.62491 4.95 5.14491 7.49C5.03491 8.01 5.47491 8.5 6.01491 8.5H10.5449Z" fill="url(#paint7_radial_18_5248)"/>
+<path d="M10.5449 8.5H15.5449C15.8211 8.5 16.0473 8.27541 16.0221 8.00042C15.7668 5.21126 13.3966 3 10.5449 3C7.87491 3 5.62491 4.95 5.14491 7.49C5.03491 8.01 5.47491 8.5 6.01491 8.5H10.5449Z" fill="url(#paint8_radial_18_5248)"/>
+<path d="M10.5449 8.5H15.5449C15.8211 8.5 16.0473 8.27541 16.0221 8.00042C15.7668 5.21126 13.3966 3 10.5449 3C7.87491 3 5.62491 4.95 5.14491 7.49C5.03491 8.01 5.47491 8.5 6.01491 8.5H10.5449Z" fill="url(#paint9_linear_18_5248)"/>
+<path d="M10.5449 8.5H15.5449C15.8211 8.5 16.0473 8.27541 16.0221 8.00042C15.7668 5.21126 13.3966 3 10.5449 3C7.87491 3 5.62491 4.95 5.14491 7.49C5.03491 8.01 5.47491 8.5 6.01491 8.5H10.5449Z" fill="url(#paint10_linear_18_5248)"/>
+<path d="M10.5449 8.5H15.5449C15.8211 8.5 16.0473 8.27541 16.0221 8.00042C15.7668 5.21126 13.3966 3 10.5449 3C7.87491 3 5.62491 4.95 5.14491 7.49C5.03491 8.01 5.47491 8.5 6.01491 8.5H10.5449Z" fill="url(#paint11_radial_18_5248)"/>
+<path d="M10.5449 8.5H15.5449C15.8211 8.5 16.0473 8.27541 16.0221 8.00042C15.7668 5.21126 13.3966 3 10.5449 3C7.87491 3 5.62491 4.95 5.14491 7.49C5.03491 8.01 5.47491 8.5 6.01491 8.5H10.5449Z" fill="url(#paint12_radial_18_5248)"/>
+<g filter="url(#filter0_i_18_5248)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M28.7591 28.0099H4.35059C6.95743 24.0402 11.4492 21.4199 16.5549 21.4199C21.6606 21.4199 26.1523 24.0402 28.7591 28.0099Z" fill="url(#paint13_radial_18_5248)"/>
+</g>
+<path d="M21.3849 8.5H16.3849C16.1087 8.5 15.8825 8.27541 15.9077 8.00042C16.163 5.21126 18.5332 3 21.3849 3C24.0549 3 26.3049 4.95 26.7849 7.49C26.8849 8.02 26.4549 8.5 25.9149 8.5H21.3849Z" fill="url(#paint14_radial_18_5248)"/>
+<path d="M21.3849 8.5H16.3849C16.1087 8.5 15.8825 8.27541 15.9077 8.00042C16.163 5.21126 18.5332 3 21.3849 3C24.0549 3 26.3049 4.95 26.7849 7.49C26.8849 8.02 26.4549 8.5 25.9149 8.5H21.3849Z" fill="url(#paint15_radial_18_5248)"/>
+<path d="M21.3849 8.5H16.3849C16.1087 8.5 15.8825 8.27541 15.9077 8.00042C16.163 5.21126 18.5332 3 21.3849 3C24.0549 3 26.3049 4.95 26.7849 7.49C26.8849 8.02 26.4549 8.5 25.9149 8.5H21.3849Z" fill="url(#paint16_linear_18_5248)"/>
+<path d="M19.1749 12.1099L16.1949 9.12993C15.8449 8.77993 15.8749 8.16993 16.2849 7.88993C18.2749 6.52993 21.0349 6.73993 22.7949 8.48993C24.5549 10.2499 24.7549 13.0099 23.3949 14.9999C23.1149 15.4099 22.5049 15.4499 22.1549 15.0899L19.1749 12.1099Z" fill="url(#paint17_radial_18_5248)"/>
+<path d="M19.1749 12.1099L16.1949 9.12993C15.8449 8.77993 15.8749 8.16993 16.2849 7.88993C18.2749 6.52993 21.0349 6.73993 22.7949 8.48993C24.5549 10.2499 24.7549 13.0099 23.3949 14.9999C23.1149 15.4099 22.5049 15.4499 22.1549 15.0899L19.1749 12.1099Z" fill="url(#paint18_radial_18_5248)"/>
+<path d="M19.1749 12.1099L16.1949 9.12993C15.8449 8.77993 15.8749 8.16993 16.2849 7.88993C18.2749 6.52993 21.0349 6.73993 22.7949 8.48993C24.5549 10.2499 24.7549 13.0099 23.3949 14.9999C23.1149 15.4099 22.5049 15.4499 22.1549 15.0899L19.1749 12.1099Z" fill="url(#paint19_radial_18_5248)"/>
+<path d="M19.1749 12.1099L16.1949 9.12993C15.8449 8.77993 15.8749 8.16993 16.2849 7.88993C18.2749 6.52993 21.0349 6.73993 22.7949 8.48993C24.5549 10.2499 24.7549 13.0099 23.3949 14.9999C23.1149 15.4099 22.5049 15.4499 22.1549 15.0899L19.1749 12.1099Z" fill="url(#paint20_radial_18_5248)"/>
+<path d="M19.1749 12.1099L16.1949 9.12993C15.8449 8.77993 15.8749 8.16993 16.2849 7.88993C18.2749 6.52993 21.0349 6.73993 22.7949 8.48993C24.5549 10.2499 24.7549 13.0099 23.3949 14.9999C23.1149 15.4099 22.5049 15.4499 22.1549 15.0899L19.1749 12.1099Z" fill="url(#paint21_linear_18_5248)"/>
+<path d="M12.645 12.1799L15.715 9.10988C16.075 8.74988 16.045 8.11988 15.615 7.82988C13.565 6.42988 10.725 6.63988 8.91497 8.44988C7.10497 10.2599 6.89497 13.1099 8.29497 15.1499C8.58497 15.5799 9.20497 15.6099 9.57497 15.2499L12.645 12.1799Z" fill="url(#paint22_radial_18_5248)"/>
+<path d="M12.645 12.1799L15.715 9.10988C16.075 8.74988 16.045 8.11988 15.615 7.82988C13.565 6.42988 10.725 6.63988 8.91497 8.44988C7.10497 10.2599 6.89497 13.1099 8.29497 15.1499C8.58497 15.5799 9.20497 15.6099 9.57497 15.2499L12.645 12.1799Z" fill="url(#paint23_radial_18_5248)"/>
+<path d="M12.645 12.1799L15.715 9.10988C16.075 8.74988 16.045 8.11988 15.615 7.82988C13.565 6.42988 10.725 6.63988 8.91497 8.44988C7.10497 10.2599 6.89497 13.1099 8.29497 15.1499C8.58497 15.5799 9.20497 15.6099 9.57497 15.2499L12.645 12.1799Z" fill="url(#paint24_radial_18_5248)"/>
+<path d="M12.645 12.1799L15.715 9.10988C16.075 8.74988 16.045 8.11988 15.615 7.82988C13.565 6.42988 10.725 6.63988 8.91497 8.44988C7.10497 10.2599 6.89497 13.1099 8.29497 15.1499C8.58497 15.5799 9.20497 15.6099 9.57497 15.2499L12.645 12.1799Z" fill="url(#paint25_linear_18_5248)"/>
+<path d="M18.455 15.01C19.5595 15.01 20.455 14.1146 20.455 13.01C20.455 11.9054 19.5595 11.01 18.455 11.01C17.3504 11.01 16.455 11.9054 16.455 13.01C16.455 14.1146 17.3504 15.01 18.455 15.01Z" fill="url(#paint26_radial_18_5248)"/>
+<path d="M18.455 15.01C19.5595 15.01 20.455 14.1146 20.455 13.01C20.455 11.9054 19.5595 11.01 18.455 11.01C17.3504 11.01 16.455 11.9054 16.455 13.01C16.455 14.1146 17.3504 15.01 18.455 15.01Z" fill="url(#paint27_radial_18_5248)"/>
+<path d="M18.455 15.01C19.5595 15.01 20.455 14.1146 20.455 13.01C20.455 11.9054 19.5595 11.01 18.455 11.01C17.3504 11.01 16.455 11.9054 16.455 13.01C16.455 14.1146 17.3504 15.01 18.455 15.01Z" fill="url(#paint28_radial_18_5248)"/>
+<path d="M18.455 15.01C19.5595 15.01 20.455 14.1146 20.455 13.01C20.455 11.9054 19.5595 11.01 18.455 11.01C17.3504 11.01 16.455 11.9054 16.455 13.01C16.455 14.1146 17.3504 15.01 18.455 15.01Z" fill="url(#paint29_radial_18_5248)"/>
+<path d="M18.455 15.01C19.5595 15.01 20.455 14.1146 20.455 13.01C20.455 11.9054 19.5595 11.01 18.455 11.01C17.3504 11.01 16.455 11.9054 16.455 13.01C16.455 14.1146 17.3504 15.01 18.455 15.01Z" fill="url(#paint30_radial_18_5248)"/>
+<path d="M18.455 15.01C19.5595 15.01 20.455 14.1146 20.455 13.01C20.455 11.9054 19.5595 11.01 18.455 11.01C17.3504 11.01 16.455 11.9054 16.455 13.01C16.455 14.1146 17.3504 15.01 18.455 15.01Z" fill="url(#paint31_radial_18_5248)"/>
+<g filter="url(#filter1_ii_18_5248)">
+<path d="M30.4891 27.9162C30.4891 27.3381 30.1567 27.0456 29.5047 26.8147C28.7547 26.5491 28.041 26.01 26.861 26.01C25.141 26.01 25.141 27.01 23.421 27.01C21.701 27.01 21.701 26.01 19.971 26.01C18.251 26.01 18.251 27.01 16.521 27.01C14.801 27.01 14.801 26.01 13.071 26.01C11.351 26.01 11.351 27.01 9.63097 27.01C7.91097 27.01 7.91097 26.01 6.18097 26.01C4.80097 26.01 4.24097 26.64 3.29097 26.89C2.82097 27.02 2.49097 27.45 2.49097 27.93C2.49097 28.53 2.97097 29.01 3.57097 29.01H29.3719C30.2157 29.01 30.4891 28.3303 30.4891 27.9162Z" fill="url(#paint32_linear_18_5248)"/>
+</g>
+<g filter="url(#filter2_f_18_5248)">
+<path d="M15.6458 8.61993L13.0809 11.025L10.2866 7.54252C12.5332 6.81962 14.631 7.66069 15.6458 8.61993Z" fill="url(#paint33_linear_18_5248)"/>
+</g>
+<g filter="url(#filter3_f_18_5248)">
+<circle cx="18.985" cy="12.7829" r="0.809222" fill="url(#paint34_radial_18_5248)"/>
+</g>
+<g filter="url(#filter4_f_18_5248)">
+<path d="M18.455 7.71217C19.3696 7.60131 22.5017 8.21108 23.3055 10.9274" stroke="url(#paint35_radial_18_5248)" stroke-width="0.5" stroke-linecap="round"/>
+</g>
+<g filter="url(#filter5_f_18_5248)">
+<ellipse cx="23.9305" cy="5.0181" rx="1.91708" ry="0.607976" transform="rotate(36.5363 23.9305 5.0181)" fill="url(#paint36_radial_18_5248)"/>
+</g>
+<g filter="url(#filter6_f_18_5248)">
+<ellipse cx="12.6378" cy="5.15207" rx="2.02056" ry="1.21271" transform="rotate(34.8384 12.6378 5.15207)" fill="url(#paint37_radial_18_5248)"/>
+</g>
+<path d="M14.475 12.99C15.574 12.99 16.465 12.0991 16.465 11C16.465 9.90096 15.574 9.01001 14.475 9.01001C13.3759 9.01001 12.485 9.90096 12.485 11C12.485 12.0991 13.3759 12.99 14.475 12.99Z" fill="url(#paint38_radial_18_5248)"/>
+<path d="M14.475 12.99C15.574 12.99 16.465 12.0991 16.465 11C16.465 9.90096 15.574 9.01001 14.475 9.01001C13.3759 9.01001 12.485 9.90096 12.485 11C12.485 12.0991 13.3759 12.99 14.475 12.99Z" fill="url(#paint39_radial_18_5248)"/>
+<path d="M14.475 12.99C15.574 12.99 16.465 12.0991 16.465 11C16.465 9.90096 15.574 9.01001 14.475 9.01001C13.3759 9.01001 12.485 9.90096 12.485 11C12.485 12.0991 13.3759 12.99 14.475 12.99Z" fill="url(#paint40_radial_18_5248)"/>
+<path d="M14.475 12.99C15.574 12.99 16.465 12.0991 16.465 11C16.465 9.90096 15.574 9.01001 14.475 9.01001C13.3759 9.01001 12.485 9.90096 12.485 11C12.485 12.0991 13.3759 12.99 14.475 12.99Z" fill="url(#paint41_radial_18_5248)"/>
+<g filter="url(#filter7_f_18_5248)">
+<ellipse cx="15.2288" cy="10.4322" rx="0.761381" ry="0.834773" transform="rotate(-28.2981 15.2288 10.4322)" fill="url(#paint42_radial_18_5248)"/>
+</g>
+<defs>
+<filter id="filter0_i_18_5248" x="4.35059" y="21.4199" width="24.5586" height="6.73997" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.15" dy="0.15"/>
+<feGaussianBlur stdDeviation="0.25"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.858824 0 0 0 0 0.611765 0 0 0 0 0.545098 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_5248"/>
+</filter>
+<filter id="filter1_ii_18_5248" x="1.99097" y="25.76" width="28.7482" height="3.25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.5"/>
+<feGaussianBlur stdDeviation="0.375"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.572549 0 0 0 0 0.952941 0 0 0 0 1 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_5248"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.25" dy="-0.25"/>
+<feGaussianBlur stdDeviation="0.375"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.341176 0 0 0 0 0.411765 0 0 0 0 0.952941 0 0 0 1 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_18_5248" result="effect2_innerShadow_18_5248"/>
+</filter>
+<filter id="filter2_f_18_5248" x="9.78662" y="6.77039" width="6.35925" height="4.75464" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.25" result="effect1_foregroundBlur_18_5248"/>
+</filter>
+<filter id="filter3_f_18_5248" x="17.1758" y="10.9736" width="3.61841" height="3.61841" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.5" result="effect1_foregroundBlur_18_5248"/>
+</filter>
+<filter id="filter4_f_18_5248" x="17.705" y="6.95007" width="6.35059" height="4.72742" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.25" result="effect1_foregroundBlur_18_5248"/>
+</filter>
+<filter id="filter5_f_18_5248" x="21.5978" y="3.02637" width="4.66528" height="3.98352" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.375" result="effect1_foregroundBlur_18_5248"/>
+</filter>
+<filter id="filter6_f_18_5248" x="10.09" y="2.87793" width="5.09558" height="4.54834" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.375" result="effect1_foregroundBlur_18_5248"/>
+</filter>
+<filter id="filter7_f_18_5248" x="13.4502" y="8.61316" width="3.55725" height="3.63806" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.5" result="effect1_foregroundBlur_18_5248"/>
+</filter>
+<linearGradient id="paint0_linear_18_5248" x1="13.9965" y1="17.4175" x2="18.985" y2="17.4175" gradientUnits="userSpaceOnUse">
+<stop stop-color="#56322E"/>
+<stop offset="0.476042" stop-color="#7E4D54"/>
+<stop offset="1" stop-color="#906C65"/>
+</linearGradient>
+<linearGradient id="paint1_linear_18_5248" x1="17.7955" y1="10.126" x2="17.608" y2="15.4609" gradientUnits="userSpaceOnUse">
+<stop stop-color="#734951"/>
+<stop offset="1" stop-color="#734951" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint2_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(16.8081 9.24135) rotate(61.6891) scale(4.34112 1.26024)">
+<stop stop-color="#4B2231"/>
+<stop offset="1" stop-color="#4B2231" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint3_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(16.49 9.10046) rotate(134.891) scale(4.69859 0.944408)">
+<stop stop-color="#4B2231"/>
+<stop offset="1" stop-color="#4B2231" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint4_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(16.8081 12.0417) rotate(118.377) scale(3.5031 2.5085)">
+<stop stop-color="#422026"/>
+<stop offset="1" stop-color="#422026" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint5_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(16.965 21.6974) rotate(-90) scale(1.6875 5.5)">
+<stop stop-color="#733629"/>
+<stop offset="1" stop-color="#733629" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint6_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(17.0587 14.3536) rotate(90) scale(3.34375 1.75)">
+<stop stop-color="#63353B"/>
+<stop offset="1" stop-color="#63353B" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint7_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(12.4407 4.98929) rotate(91.3983) scale(4.68221 10.8024)">
+<stop stop-color="#9ED141"/>
+<stop offset="1" stop-color="#799D4B"/>
+</radialGradient>
+<radialGradient id="paint8_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(11.3022 6.13185) rotate(90) scale(2.36814 6.17429)">
+<stop stop-color="#9AC644"/>
+<stop offset="1" stop-color="#9AC644" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint9_linear_18_5248" x1="15.7648" y1="8.78555" x2="14.4703" y2="6.65653" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5D9501"/>
+<stop offset="1" stop-color="#5D9501" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint10_linear_18_5248" x1="9.29039" y1="8.89612" x2="9.29039" y2="7.93784" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9C99A6"/>
+<stop offset="1" stop-color="#9C99A6" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint11_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(9.78946 8.5) rotate(160.981) scale(3.67981 1.47839)">
+<stop stop-color="#66981B"/>
+<stop offset="1" stop-color="#66981B" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint12_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(12.4573 7.51623) rotate(176.376) scale(7.99671 6.62621)">
+<stop offset="0.746552" stop-color="#82AB5A" stop-opacity="0"/>
+<stop offset="0.984356" stop-color="#82AB5A"/>
+</radialGradient>
+<radialGradient id="paint13_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(24.2774 25.9474) rotate(-180) scale(12.5625 10.6845)">
+<stop stop-color="#FFC351"/>
+<stop offset="1" stop-color="#F07B4C"/>
+</radialGradient>
+<radialGradient id="paint14_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(25.5572 6.58346) rotate(-180) scale(12.9552 13.6351)">
+<stop stop-color="#A3D350"/>
+<stop offset="1" stop-color="#679E15"/>
+</radialGradient>
+<radialGradient id="paint15_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(24.9291 5.90527) rotate(-180) scale(7.39188 4.17791)">
+<stop stop-color="#A3CF56"/>
+<stop offset="1" stop-color="#A3CF56" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint16_linear_18_5248" x1="23.8218" y1="9.25043" x2="23.8218" y2="7.96936" gradientUnits="userSpaceOnUse">
+<stop stop-color="#95A096"/>
+<stop offset="1" stop-color="#95A096" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint17_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(21.8346 9.41588) rotate(136.119) scale(3.63151 6.30902)">
+<stop stop-color="#74A550"/>
+<stop offset="1" stop-color="#517D2A"/>
+</radialGradient>
+<radialGradient id="paint18_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(19.6122 13.4385) rotate(-47.7616) scale(1.80001 7.40969)">
+<stop stop-color="#576043"/>
+<stop offset="1" stop-color="#576043" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint19_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(13.9326 7.78709) rotate(30.3907) scale(12.0004 11.1076)">
+<stop offset="0.756577" stop-color="#6C9543" stop-opacity="0"/>
+<stop offset="1" stop-color="#6C9543"/>
+</radialGradient>
+<radialGradient id="paint20_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(18.7849 11.7233) rotate(-103.229) scale(2.10416 1.0655)">
+<stop stop-color="#3E6A0C"/>
+<stop offset="1" stop-color="#3E6A0C" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint21_linear_18_5248" x1="18.9436" y1="12.3971" x2="19.631" y2="11.7092" gradientUnits="userSpaceOnUse">
+<stop stop-color="#394B28"/>
+<stop offset="1" stop-color="#394B28" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint22_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(13.6535 10.3048) rotate(118.593) scale(7.03305 6.38687)">
+<stop stop-color="#65943F"/>
+<stop offset="1" stop-color="#4C712C"/>
+</radialGradient>
+<radialGradient id="paint23_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(12.2599 11.2071) rotate(134.648) scale(3.95065 1.19038)">
+<stop stop-color="#69785C"/>
+<stop offset="1" stop-color="#69785C" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint24_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(13.1744 11.0597) rotate(133.788) scale(2.17092 2.05402)">
+<stop stop-color="#4E5E45"/>
+<stop offset="1" stop-color="#4E5E45" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint25_linear_18_5248" x1="11.9006" y1="12.5551" x2="11.6146" y2="12.2938" gradientUnits="userSpaceOnUse">
+<stop stop-color="#617247"/>
+<stop offset="1" stop-color="#617247" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint26_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(18.9788 13.01) rotate(130.622) scale(2.95189 3.725)">
+<stop stop-color="#B97056"/>
+<stop offset="1" stop-color="#82582F"/>
+</radialGradient>
+<radialGradient id="paint27_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(18.0725 15.01) rotate(-83.4151) scale(2.18007 2.3935)">
+<stop stop-color="#B5547D"/>
+<stop offset="1" stop-color="#B5547D" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint28_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(19.4866 14.899) rotate(-125.655) scale(0.442286 1.4276)">
+<stop stop-color="#AD619B"/>
+<stop offset="1" stop-color="#AD619B" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint29_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(16.4944 14.2818) rotate(-32.9053) scale(0.632763 1.04366)">
+<stop stop-color="#AD619B"/>
+<stop offset="1" stop-color="#AD619B" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint30_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(16.709 14.4049) rotate(-33.947) scale(4.51568 4.0109)">
+<stop offset="0.817127" stop-color="#AC794F" stop-opacity="0"/>
+<stop offset="1" stop-color="#AC794F"/>
+</radialGradient>
+<radialGradient id="paint31_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(16.455 12.0876) rotate(90) scale(1.59191 0.539146)">
+<stop stop-color="#893E2F"/>
+<stop offset="1" stop-color="#893E2F" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint32_linear_18_5248" x1="3.59" y1="29.01" x2="30.0275" y2="29.01" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5884FF"/>
+<stop offset="1" stop-color="#6DD5FF"/>
+</linearGradient>
+<linearGradient id="paint33_linear_18_5248" x1="14.485" y1="8.74505" x2="11.2876" y2="9.38454" gradientUnits="userSpaceOnUse">
+<stop stop-color="#7C9D5A"/>
+<stop offset="1" stop-color="#7C9D5A" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint34_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(19.3751 12.5983) rotate(151.44) scale(2.37084)">
+<stop stop-color="#D79F87"/>
+<stop offset="1" stop-color="#D79F87" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint35_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(21.8642 8.21108) rotate(132.065) scale(1.53074 4.60025)">
+<stop stop-color="#80B35C"/>
+<stop offset="1" stop-color="#80B35C" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint36_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(25.7796 4.82974) rotate(-177.877) scale(3.54928 0.660578)">
+<stop stop-color="#C0EF77"/>
+<stop offset="1" stop-color="#C0EF77" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint37_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(15.4649 4.84369) rotate(172.726) scale(4.96326 1.74112)">
+<stop stop-color="#B8E172"/>
+<stop offset="1" stop-color="#B8E172" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint38_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(14.9962 11) rotate(130.622) scale(2.93713 3.70637)">
+<stop stop-color="#AA674F"/>
+<stop offset="1" stop-color="#82582F"/>
+</radialGradient>
+<radialGradient id="paint39_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(14.0944 12.99) rotate(-83.4151) scale(2.16917 2.38153)">
+<stop stop-color="#AC4D77"/>
+<stop offset="1" stop-color="#AC4D77" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint40_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(13.8457 13.0583) rotate(-72.2553) scale(0.408087 0.936502)">
+<stop stop-color="#AD619B"/>
+<stop offset="1" stop-color="#AD619B" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint41_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(12.7377 12.3879) rotate(-33.947) scale(4.4931 3.99084)">
+<stop offset="0.773245" stop-color="#AC794F" stop-opacity="0"/>
+<stop offset="1" stop-color="#AC794F"/>
+</radialGradient>
+<radialGradient id="paint42_radial_18_5248" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(15.5959 10.2418) rotate(149.172) scale(2.2816 2.3911)">
+<stop stop-color="#D79F87"/>
+<stop offset="1" stop-color="#D79F87" stop-opacity="0"/>
+</radialGradient>
+</defs>
+</svg>

--- a/public/icons/emoji/ice-skate.svg
+++ b/public/icons/emoji/ice-skate.svg
@@ -1,0 +1,202 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_ii_18_2809)">
+<path d="M27.22 24.68V25.37C27.22 26.41 26.38 27.25 25.34 27.25H24.43C23.82 27.25 23.32 26.75 23.32 26.14V23.8275H20.53V26.14C20.53 26.75 20.03 27.25 19.42 27.25H9.55C8.94 27.25 8.44 26.75 8.44 26.14V23.8275H5.65V26.14C5.65 26.75 5.15 27.25 4.54 27.25H3.4C2.63 27.25 2 27.88 2 28.65C2 29.42 2.63 30.05 3.4 30.05H25.33C27.91 30.05 30 27.96 30 25.38V24.69C30 23.92 29.37 23.29 28.6 23.29C27.85 23.29 27.22 23.91 27.22 24.68Z" fill="#D7C9E7"/>
+<path d="M27.22 24.68V25.37C27.22 26.41 26.38 27.25 25.34 27.25H24.43C23.82 27.25 23.32 26.75 23.32 26.14V23.8275H20.53V26.14C20.53 26.75 20.03 27.25 19.42 27.25H9.55C8.94 27.25 8.44 26.75 8.44 26.14V23.8275H5.65V26.14C5.65 26.75 5.15 27.25 4.54 27.25H3.4C2.63 27.25 2 27.88 2 28.65C2 29.42 2.63 30.05 3.4 30.05H25.33C27.91 30.05 30 27.96 30 25.38V24.69C30 23.92 29.37 23.29 28.6 23.29C27.85 23.29 27.22 23.91 27.22 24.68Z" fill="url(#paint0_radial_18_2809)"/>
+<path d="M27.22 24.68V25.37C27.22 26.41 26.38 27.25 25.34 27.25H24.43C23.82 27.25 23.32 26.75 23.32 26.14V23.8275H20.53V26.14C20.53 26.75 20.03 27.25 19.42 27.25H9.55C8.94 27.25 8.44 26.75 8.44 26.14V23.8275H5.65V26.14C5.65 26.75 5.15 27.25 4.54 27.25H3.4C2.63 27.25 2 27.88 2 28.65C2 29.42 2.63 30.05 3.4 30.05H25.33C27.91 30.05 30 27.96 30 25.38V24.69C30 23.92 29.37 23.29 28.6 23.29C27.85 23.29 27.22 23.91 27.22 24.68Z" fill="url(#paint1_radial_18_2809)"/>
+</g>
+<path d="M27.22 24.68V25.37C27.22 26.41 26.38 27.25 25.34 27.25H24.43C23.82 27.25 23.32 26.75 23.32 26.14V23.8275H20.53V26.14C20.53 26.75 20.03 27.25 19.42 27.25H9.55C8.94 27.25 8.44 26.75 8.44 26.14V23.8275H5.65V26.14C5.65 26.75 5.15 27.25 4.54 27.25H3.4C2.63 27.25 2 27.88 2 28.65C2 29.42 2.63 30.05 3.4 30.05H25.33C27.91 30.05 30 27.96 30 25.38V24.69C30 23.92 29.37 23.29 28.6 23.29C27.85 23.29 27.22 23.91 27.22 24.68Z" fill="url(#paint2_radial_18_2809)"/>
+<path d="M27.22 24.68V25.37C27.22 26.41 26.38 27.25 25.34 27.25H24.43C23.82 27.25 23.32 26.75 23.32 26.14V23.8275H20.53V26.14C20.53 26.75 20.03 27.25 19.42 27.25H9.55C8.94 27.25 8.44 26.75 8.44 26.14V23.8275H5.65V26.14C5.65 26.75 5.15 27.25 4.54 27.25H3.4C2.63 27.25 2 27.88 2 28.65C2 29.42 2.63 30.05 3.4 30.05H25.33C27.91 30.05 30 27.96 30 25.38V24.69C30 23.92 29.37 23.29 28.6 23.29C27.85 23.29 27.22 23.91 27.22 24.68Z" fill="url(#paint3_radial_18_2809)"/>
+<g filter="url(#filter1_ii_18_2809)">
+<path d="M21.8294 16.161C23.9937 17.0811 25.7234 17.8164 25.76 20.27L25.75 21.2459L25.3808 20.5H4.51001V5.70999C4.51001 5.31999 4.83001 5 5.22001 5H13.43C13.82 5 14.14 5.31999 14.14 5.70999V11.82C14.14 12.67 14.68 13.1 15.58 13.58C17.6642 14.4373 19.7554 15.2793 21.8294 16.161Z" fill="#D5C9E2"/>
+</g>
+<path d="M21.8294 16.161C23.9937 17.0811 25.7234 17.8164 25.76 20.27L25.75 21.2459L25.3808 20.5H4.51001V5.70999C4.51001 5.31999 4.83001 5 5.22001 5H13.43C13.82 5 14.14 5.31999 14.14 5.70999V11.82C14.14 12.67 14.68 13.1 15.58 13.58C17.6642 14.4373 19.7554 15.2793 21.8294 16.161Z" fill="url(#paint4_radial_18_2809)"/>
+<path d="M21.8294 16.161C23.9937 17.0811 25.7234 17.8164 25.76 20.27L25.75 21.2459L25.3808 20.5H4.51001V5.70999C4.51001 5.31999 4.83001 5 5.22001 5H13.43C13.82 5 14.14 5.31999 14.14 5.70999V11.82C14.14 12.67 14.68 13.1 15.58 13.58C17.6642 14.4373 19.7554 15.2793 21.8294 16.161Z" fill="url(#paint5_radial_18_2809)"/>
+<path d="M21.8294 16.161C23.9937 17.0811 25.7234 17.8164 25.76 20.27L25.75 21.2459L25.3808 20.5H4.51001V5.70999C4.51001 5.31999 4.83001 5 5.22001 5H13.43C13.82 5 14.14 5.31999 14.14 5.70999V11.82C14.14 12.67 14.68 13.1 15.58 13.58C17.6642 14.4373 19.7554 15.2793 21.8294 16.161Z" fill="url(#paint6_radial_18_2809)"/>
+<g filter="url(#filter2_iii_18_2809)">
+<path d="M25.75 22.56V20.7567C25.75 20.4819 25.5282 20.2586 25.2534 20.2567L10.84 20.16C10.63 20.16 10.45 20.04 10.36 19.85L9.85001 18.76C9.50001 18.01 8.74001 17.52 7.91001 17.52H5.01001C4.73387 17.52 4.51001 17.7439 4.51001 18.02V22.55V24.06C4.51001 24.35 4.75001 24.59 5.04001 24.59H9.79001C10.08 24.59 10.32 24.35 10.32 24.06V23.07C10.32 22.78 10.55 22.55 10.84 22.55H14C14.29 22.55 14.52 22.78 14.52 23.07V24.06C14.52 24.35 14.76 24.59 15.05 24.59H25.24C25.53 24.59 25.77 24.35 25.77 24.06L25.75 22.56Z" fill="url(#paint7_linear_18_2809)"/>
+<path d="M25.75 22.56V20.7567C25.75 20.4819 25.5282 20.2586 25.2534 20.2567L10.84 20.16C10.63 20.16 10.45 20.04 10.36 19.85L9.85001 18.76C9.50001 18.01 8.74001 17.52 7.91001 17.52H5.01001C4.73387 17.52 4.51001 17.7439 4.51001 18.02V22.55V24.06C4.51001 24.35 4.75001 24.59 5.04001 24.59H9.79001C10.08 24.59 10.32 24.35 10.32 24.06V23.07C10.32 22.78 10.55 22.55 10.84 22.55H14C14.29 22.55 14.52 22.78 14.52 23.07V24.06C14.52 24.35 14.76 24.59 15.05 24.59H25.24C25.53 24.59 25.77 24.35 25.77 24.06L25.75 22.56Z" fill="url(#paint8_radial_18_2809)"/>
+</g>
+<path d="M25.75 22.56V20.7567C25.75 20.4819 25.5282 20.2586 25.2534 20.2567L10.84 20.16C10.63 20.16 10.45 20.04 10.36 19.85L9.85001 18.76C9.50001 18.01 8.74001 17.52 7.91001 17.52H5.01001C4.73387 17.52 4.51001 17.7439 4.51001 18.02V22.55V24.06C4.51001 24.35 4.75001 24.59 5.04001 24.59H9.79001C10.08 24.59 10.32 24.35 10.32 24.06V23.07C10.32 22.78 10.55 22.55 10.84 22.55H14C14.29 22.55 14.52 22.78 14.52 23.07V24.06C14.52 24.35 14.76 24.59 15.05 24.59H25.24C25.53 24.59 25.77 24.35 25.77 24.06L25.75 22.56Z" fill="url(#paint9_radial_18_2809)"/>
+<g filter="url(#filter3_f_18_2809)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M9.97034 10.7972C9.97034 10.5211 10.2154 10.2972 10.5176 10.2972H13.5867C13.889 10.2972 14.134 10.5211 14.134 10.7972C14.134 11.0734 13.889 11.2972 13.5867 11.2972H10.5176C10.2154 11.2972 9.97034 11.0734 9.97034 10.7972Z" fill="url(#paint10_linear_18_2809)"/>
+</g>
+<g filter="url(#filter4_i_18_2809)">
+<path d="M14.31 10.5H10.54" stroke="#B7B6BA" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.31 10.5H10.54" stroke="url(#paint11_linear_18_2809)" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<g filter="url(#filter5_f_18_2809)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M9.97034 7.69736C9.97034 7.42121 10.2154 7.19736 10.5176 7.19736H13.5867C13.889 7.19736 14.134 7.42121 14.134 7.69736C14.134 7.9735 13.889 8.19736 13.5867 8.19736H10.5176C10.2154 8.19736 9.97034 7.9735 9.97034 7.69736Z" fill="url(#paint12_linear_18_2809)"/>
+</g>
+<g filter="url(#filter6_i_18_2809)">
+<path d="M14.31 7.5H10.54" stroke="#B7B6BA" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.31 7.5H10.54" stroke="url(#paint13_linear_18_2809)" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<g filter="url(#filter7_f_18_2809)">
+<path d="M7.73807 25.9042C7.62765 26.5874 7.86643 27.9539 9.70493 27.9539" stroke="url(#paint14_linear_18_2809)" stroke-width="0.4" stroke-linecap="round"/>
+</g>
+<g filter="url(#filter8_f_18_2809)">
+<path d="M22.6862 25.3452V26.546C22.7414 27.0498 23.1168 28.0574 24.1769 28.0574" stroke="url(#paint15_linear_18_2809)" stroke-width="0.4" stroke-linecap="round"/>
+</g>
+<defs>
+<filter id="filter0_ii_18_2809" x="2" y="22.69" width="28.5" height="7.86001" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-0.6"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.752941 0 0 0 0 0.603922 0 0 0 0 0.890196 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_2809"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.5"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.635294 0 0 0 0 0.588235 0 0 0 0 0.690196 0 0 0 1 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_18_2809" result="effect2_innerShadow_18_2809"/>
+</filter>
+<filter id="filter1_ii_18_2809" x="3.01001" y="5" width="24" height="17.2458" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-1.5" dy="1"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.945098 0 0 0 0 0.937255 0 0 0 0 0.952941 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_2809"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1.25"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.615686 0 0 0 0 0.588235 0 0 0 0 0.643137 0 0 0 1 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_18_2809" result="effect2_innerShadow_18_2809"/>
+</filter>
+<filter id="filter2_iii_18_2809" x="4.11001" y="17.12" width="22.16" height="7.87001" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-0.4"/>
+<feGaussianBlur stdDeviation="0.375"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.27451 0 0 0 0 0.192157 0 0 0 0 0.384314 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_2809"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="-0.25"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.27451 0 0 0 0 0.192157 0 0 0 0 0.384314 0 0 0 1 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_18_2809" result="effect2_innerShadow_18_2809"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.4" dy="0.4"/>
+<feGaussianBlur stdDeviation="0.3"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.513726 0 0 0 0 0.529412 0 0 0 0 0.72549 0 0 0 1 0"/>
+<feBlend mode="normal" in2="effect2_innerShadow_18_2809" result="effect3_innerShadow_18_2809"/>
+</filter>
+<filter id="filter3_f_18_2809" x="9.47034" y="9.79721" width="5.1637" height="2" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.25" result="effect1_foregroundBlur_18_2809"/>
+</filter>
+<filter id="filter4_i_18_2809" x="10.04" y="9.75" width="5.02002" height="1.25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.25" dy="-0.25"/>
+<feGaussianBlur stdDeviation="0.25"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.509804 0 0 0 0 0.498039 0 0 0 0 0.52549 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_2809"/>
+</filter>
+<filter id="filter5_f_18_2809" x="9.47034" y="6.69736" width="5.1637" height="2" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.25" result="effect1_foregroundBlur_18_2809"/>
+</filter>
+<filter id="filter6_i_18_2809" x="10.04" y="6.75" width="5.02002" height="1.25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.25" dy="-0.25"/>
+<feGaussianBlur stdDeviation="0.25"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.509804 0 0 0 0 0.498039 0 0 0 0 0.52549 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_2809"/>
+</filter>
+<filter id="filter7_f_18_2809" x="7.2155" y="25.4042" width="2.9894" height="3.04971" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.15" result="effect1_foregroundBlur_18_2809"/>
+</filter>
+<filter id="filter8_f_18_2809" x="21.8862" y="24.5452" width="3.09069" height="4.31218" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.3" result="effect1_foregroundBlur_18_2809"/>
+</filter>
+<radialGradient id="paint0_radial_18_2809" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(7.22052 23.5854) rotate(74.2569) scale(3.20486 4.48426)">
+<stop offset="0.204984" stop-color="#A594B8"/>
+<stop offset="1" stop-color="#A594B8" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint1_radial_18_2809" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(20.7608 23.5854) rotate(69.0755) scale(3.01451 4.21792)">
+<stop offset="0.415849" stop-color="#A594B8"/>
+<stop offset="1" stop-color="#A594B8" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint2_radial_18_2809" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(29.7462 23.5026) rotate(90) scale(2.89852 2.41605)">
+<stop stop-color="#F9F5FE"/>
+<stop offset="1" stop-color="#F9F5FE" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint3_radial_18_2809" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(24.1976 25.5522) rotate(126.968) scale(2.40992 2.20647)">
+<stop offset="0.153591" stop-color="#E4DEEB"/>
+<stop offset="1" stop-color="#E4DEEB" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint4_radial_18_2809" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(20.2639 14.3929) rotate(107.241) scale(2.51463 9.87412)">
+<stop offset="0.142083" stop-color="#ECEBED"/>
+<stop offset="1" stop-color="#ECEBED" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint5_radial_18_2809" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(25.9999 17.4375) rotate(124.077) scale(2.56555 6.06964)">
+<stop stop-color="#F0EFF1"/>
+<stop offset="1" stop-color="#F0EFF1" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint6_radial_18_2809" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(16.8124 6.5) rotate(-176.46) scale(6.07409 2.074)">
+<stop stop-color="#F0EFF2"/>
+<stop offset="1" stop-color="#F0EFF2" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint7_linear_18_2809" x1="4.51001" y1="22.1472" x2="25.77" y2="22.0649" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5B4778"/>
+<stop offset="1" stop-color="#6A69A0"/>
+</linearGradient>
+<radialGradient id="paint8_radial_18_2809" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(9.68741 17.52) rotate(143.79) scale(3.56322 3.72443)">
+<stop offset="0.266622" stop-color="#72618F"/>
+<stop offset="1" stop-color="#72618F" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint9_radial_18_2809" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(6.31241 15.4375) rotate(56.4451) scale(7.3498 15.543)">
+<stop stop-color="#604D7B"/>
+<stop offset="1" stop-color="#604D7B" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint10_linear_18_2809" x1="10.2414" y1="10.9458" x2="14.134" y2="10.9458" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BBB8BE"/>
+<stop offset="1" stop-color="#BCB9BF"/>
+</linearGradient>
+<linearGradient id="paint11_linear_18_2809" x1="15.0744" y1="10.5" x2="14.0528" y2="10.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#D8D7DB"/>
+<stop offset="1" stop-color="#D8D7DB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint12_linear_18_2809" x1="10.2414" y1="7.84598" x2="14.134" y2="7.84598" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BBB8BE"/>
+<stop offset="1" stop-color="#BCB9BF"/>
+</linearGradient>
+<linearGradient id="paint13_linear_18_2809" x1="15.0744" y1="7.5" x2="14.0528" y2="7.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#D8D7DB"/>
+<stop offset="1" stop-color="#D8D7DB" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint14_linear_18_2809" x1="7.71545" y1="25.7385" x2="9.35297" y2="28.0781" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E4D8EF" stop-opacity="0"/>
+<stop offset="0.539202" stop-color="#E4D8EF"/>
+<stop offset="1" stop-color="#E4D8EF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint15_linear_18_2809" x1="22.4171" y1="24.6206" x2="25.4529" y2="26.8846" gradientUnits="userSpaceOnUse">
+<stop stop-color="#EFE8F9" stop-opacity="0"/>
+<stop offset="0.539202" stop-color="#EFE8F9"/>
+<stop offset="1" stop-color="#EFE8F9" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/public/icons/emoji/love-hotel.svg
+++ b/public/icons/emoji/love-hotel.svg
@@ -1,0 +1,435 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.4047 9.83002H2.8833V29.74H15.4047V9.83002Z" fill="#F8A18D"/>
+<path d="M15.4047 9.83002H2.8833V29.74H15.4047V9.83002Z" fill="url(#paint0_linear_18_6492)"/>
+<path d="M15.4047 9.83002H2.8833V29.74H15.4047V9.83002Z" fill="url(#paint1_linear_18_6492)"/>
+<path d="M15.4047 9.83002H2.8833V29.74H15.4047V9.83002Z" fill="url(#paint2_linear_18_6492)"/>
+<path d="M28.8833 9.83002H16V29.74H28.8833V9.83002Z" fill="url(#paint3_linear_18_6492)"/>
+<path d="M28.8833 9.83002H16V29.74H28.8833V9.83002Z" fill="url(#paint4_linear_18_6492)"/>
+<path d="M28.8833 9.83002H16V29.74H28.8833V9.83002Z" fill="url(#paint5_linear_18_6492)"/>
+<path d="M28.8833 9.83002H16V29.74H28.8833V9.83002Z" fill="url(#paint6_radial_18_6492)"/>
+<path d="M28.8833 9.83002H16V29.74H28.8833V9.83002Z" fill="url(#paint7_radial_18_6492)"/>
+<path d="M21.4042 29.7401H10.272V8.37091C10.272 5.25938 12.7601 2.74005 15.8331 2.74005C18.9061 2.74005 21.3943 5.25938 21.3943 8.37091V29.7401H21.4042Z" fill="url(#paint8_linear_18_6492)"/>
+<path d="M21.4042 29.7401H10.272V8.37091C10.272 5.25938 12.7601 2.74005 15.8331 2.74005C18.9061 2.74005 21.3943 5.25938 21.3943 8.37091V29.7401H21.4042Z" fill="url(#paint9_linear_18_6492)"/>
+<path d="M21.4042 29.7401H10.272V8.37091C10.272 5.25938 12.7601 2.74005 15.8331 2.74005C18.9061 2.74005 21.3943 5.25938 21.3943 8.37091V29.7401H21.4042Z" fill="url(#paint10_linear_18_6492)"/>
+<g filter="url(#filter0_i_18_6492)">
+<path d="M7.30406 17.75H5.52406C5.18406 17.75 4.91406 17.48 4.91406 17.14V15.25C4.91406 14.42 5.58406 13.75 6.41406 13.75C7.24406 13.75 7.91406 14.42 7.91406 15.25V17.14C7.91406 17.47 7.64406 17.75 7.30406 17.75Z" fill="url(#paint11_linear_18_6492)"/>
+<path d="M7.30406 17.75H5.52406C5.18406 17.75 4.91406 17.48 4.91406 17.14V15.25C4.91406 14.42 5.58406 13.75 6.41406 13.75C7.24406 13.75 7.91406 14.42 7.91406 15.25V17.14C7.91406 17.47 7.64406 17.75 7.30406 17.75Z" fill="url(#paint12_linear_18_6492)"/>
+</g>
+<g filter="url(#filter1_i_18_6492)">
+<path d="M7.30406 24.75H5.52406C5.18406 24.75 4.91406 24.48 4.91406 24.14V22.25C4.91406 21.42 5.58406 20.75 6.41406 20.75C7.24406 20.75 7.91406 21.42 7.91406 22.25V24.14C7.91406 24.47 7.64406 24.75 7.30406 24.75Z" fill="url(#paint13_linear_18_6492)"/>
+<path d="M7.30406 24.75H5.52406C5.18406 24.75 4.91406 24.48 4.91406 24.14V22.25C4.91406 21.42 5.58406 20.75 6.41406 20.75C7.24406 20.75 7.91406 21.42 7.91406 22.25V24.14C7.91406 24.47 7.64406 24.75 7.30406 24.75Z" fill="url(#paint14_linear_18_6492)"/>
+</g>
+<g filter="url(#filter2_i_18_6492)">
+<path d="M26.3041 17.75H24.5241C24.1841 17.75 23.9141 17.48 23.9141 17.14V15.25C23.9141 14.42 24.5841 13.75 25.4141 13.75C26.2441 13.75 26.9141 14.42 26.9141 15.25V17.14C26.9141 17.47 26.6441 17.75 26.3041 17.75Z" fill="url(#paint15_linear_18_6492)"/>
+<path d="M26.3041 17.75H24.5241C24.1841 17.75 23.9141 17.48 23.9141 17.14V15.25C23.9141 14.42 24.5841 13.75 25.4141 13.75C26.2441 13.75 26.9141 14.42 26.9141 15.25V17.14C26.9141 17.47 26.6441 17.75 26.3041 17.75Z" fill="url(#paint16_linear_18_6492)"/>
+</g>
+<g filter="url(#filter3_i_18_6492)">
+<path d="M26.3041 24.75H24.5241C24.1841 24.75 23.9141 24.48 23.9141 24.14V22.25C23.9141 21.42 24.5841 20.75 25.4141 20.75C26.2441 20.75 26.9141 21.42 26.9141 22.25V24.14C26.9141 24.47 26.6441 24.75 26.3041 24.75Z" fill="url(#paint17_linear_18_6492)"/>
+<path d="M26.3041 24.75H24.5241C24.1841 24.75 23.9141 24.48 23.9141 24.14V22.25C23.9141 21.42 24.5841 20.75 25.4141 20.75C26.2441 20.75 26.9141 21.42 26.9141 22.25V24.14C26.9141 24.47 26.6441 24.75 26.3041 24.75Z" fill="url(#paint18_linear_18_6492)"/>
+</g>
+<g filter="url(#filter4_f_18_6492)">
+<path d="M17.1866 11.9161H17.1667C16.8973 11.9161 16.6779 12.1319 16.6779 12.3967V13.8777H14.6731V12.3967C14.6731 12.1319 14.4536 11.9161 14.1843 11.9161H14.1644C13.8951 11.9161 13.6757 12.1319 13.6757 12.3967V16.3395C13.6757 16.6043 13.8951 16.8201 14.1644 16.8201H14.1843C14.4536 16.8201 14.6731 16.6043 14.6731 16.3395V14.8683H16.6779V16.3395C16.6779 16.6043 16.8973 16.8201 17.1667 16.8201H17.1866C17.4559 16.8201 17.6753 16.6043 17.6753 16.3395V12.3967C17.6853 12.1319 17.4659 11.9161 17.1866 11.9161Z" fill="#B14E46"/>
+</g>
+<g filter="url(#filter5_ii_18_6492)">
+<path d="M17.425 11.75H17.4051C17.1357 11.75 16.9163 11.97 16.9163 12.24V13.75H14.9115V12.24C14.9115 11.97 14.692 11.75 14.4227 11.75H14.4028C14.1335 11.75 13.9141 11.97 13.9141 12.24V16.26C13.9141 16.53 14.1335 16.75 14.4028 16.75H14.4227C14.692 16.75 14.9115 16.53 14.9115 16.26V14.76H16.9163V16.26C16.9163 16.53 17.1357 16.75 17.4051 16.75H17.425C17.6943 16.75 17.9137 16.53 17.9137 16.26V12.24C17.9237 11.97 17.7043 11.75 17.425 11.75Z" fill="url(#paint19_linear_18_6492)"/>
+</g>
+<rect x="11.4609" y="20.3438" width="8.90625" height="9.39628" fill="url(#paint20_linear_18_6492)"/>
+<rect x="11.4609" y="20.3438" width="8.90625" height="9.39628" fill="url(#paint21_linear_18_6492)"/>
+<rect x="11.4609" y="20.3438" width="8.90625" height="9.39628" fill="url(#paint22_radial_18_6492)"/>
+<rect x="11.4609" y="20.3438" width="8.90625" height="9.39628" fill="url(#paint23_radial_18_6492)"/>
+<rect x="11.4609" y="20.3438" width="8.90625" height="9.39628" fill="url(#paint24_radial_18_6492)"/>
+<g filter="url(#filter6_f_18_6492)">
+<path d="M20.1579 22.0646V20.2842C20.1499 20.2762 20.1419 20.2681 20.1338 20.2601H11.6984C11.689 20.2695 11.6796 20.2788 11.6703 20.2882V22.0589C11.6836 22.0557 11.6973 22.0539 11.7114 22.0539C11.7709 22.0539 11.8251 22.0851 11.8657 22.1286C11.9598 22.2291 12.0882 22.2922 12.2355 22.2922C12.3828 22.2922 12.5112 22.2291 12.6053 22.1286C12.646 22.0851 12.7001 22.0539 12.7597 22.0539C12.8192 22.0539 12.8733 22.0851 12.914 22.1286C13.0081 22.2291 13.1365 22.2922 13.2838 22.2922C13.4311 22.2922 13.5595 22.2291 13.6536 22.1286C13.6943 22.0851 13.7484 22.0539 13.808 22.0539C13.8675 22.0539 13.9216 22.0851 13.9623 22.1286C14.0564 22.2291 14.1848 22.2922 14.3321 22.2922C14.4794 22.2922 14.6078 22.2291 14.7019 22.1286C14.7426 22.0851 14.7967 22.0539 14.8563 22.0539C14.9158 22.0539 14.9699 22.0851 15.0106 22.1286C15.1047 22.2291 15.2331 22.2922 15.3804 22.2922C15.5277 22.2922 15.6561 22.2291 15.7502 22.1286C15.7909 22.0851 15.845 22.0539 15.9046 22.0539C15.9641 22.0539 16.0182 22.0851 16.0589 22.1286C16.153 22.2291 16.2814 22.2922 16.4287 22.2922C16.576 22.2922 16.7044 22.2291 16.7985 22.1286C16.8392 22.0851 16.8933 22.0539 16.9528 22.0539C17.0124 22.0539 17.0665 22.0851 17.1072 22.1286C17.2013 22.2291 17.3297 22.2922 17.477 22.2922C17.6243 22.2922 17.7527 22.2291 17.8468 22.1286C17.8875 22.0851 17.9416 22.0539 18.0011 22.0539C18.0607 22.0539 18.1148 22.0851 18.1555 22.1286C18.2496 22.2291 18.378 22.2922 18.5253 22.2922C18.6726 22.2922 18.801 22.2291 18.8951 22.1286C18.9358 22.0851 18.9899 22.0539 19.0494 22.0539C19.109 22.0539 19.1631 22.0851 19.2038 22.1286C19.2979 22.2291 19.4263 22.2922 19.5736 22.2922C19.7209 22.2922 19.8493 22.2291 19.9434 22.1286C19.984 22.0851 20.0382 22.0539 20.0977 22.0539C20.1186 22.0539 20.1387 22.0577 20.1579 22.0646Z" fill="url(#paint25_linear_18_6492)"/>
+</g>
+<g filter="url(#filter7_ii_18_6492)">
+<rect x="12.4188" y="19.7501" width="2.98596" height="8.58904" rx="0.4" fill="url(#paint26_linear_18_6492)"/>
+</g>
+<g filter="url(#filter8_ii_18_6492)">
+<rect x="16.4211" y="19.7501" width="2.98596" height="8.58904" rx="0.4" fill="url(#paint27_linear_18_6492)"/>
+</g>
+<g filter="url(#filter9_f_18_6492)">
+<path d="M16.5464 22.0428V20.1814H19.2817V22.0167C19.2103 21.9912 19.1472 21.9483 19.0955 21.893C19.0582 21.8532 19.0086 21.8246 18.9541 21.8246C18.8995 21.8246 18.8499 21.8532 18.8127 21.893C18.7265 21.9851 18.6089 22.0429 18.4739 22.0429C18.339 22.0429 18.2214 21.9851 18.1352 21.893C18.0979 21.8532 18.0483 21.8246 17.9938 21.8246C17.9392 21.8246 17.8897 21.8532 17.8524 21.893C17.7662 21.9851 17.6486 22.0429 17.5136 22.0429C17.3787 22.0429 17.2611 21.9851 17.1749 21.893C17.1376 21.8532 17.088 21.8246 17.0335 21.8246C16.9789 21.8246 16.9294 21.8532 16.8921 21.893C16.8059 21.9851 16.6883 22.0429 16.5533 22.0429C16.551 22.0429 16.5487 22.0429 16.5464 22.0428Z" fill="#275FB2"/>
+</g>
+<g filter="url(#filter10_f_18_6492)">
+<path d="M12.5441 22.0428V20.1814H15.2794V22.0167C15.208 21.9912 15.1449 21.9483 15.0932 21.893C15.0559 21.8532 15.0063 21.8246 14.9518 21.8246C14.8972 21.8246 14.8476 21.8532 14.8104 21.893C14.7242 21.9851 14.6066 22.0429 14.4716 22.0429C14.3367 22.0429 14.219 21.9851 14.1329 21.893C14.0956 21.8532 14.046 21.8246 13.9915 21.8246C13.9369 21.8246 13.8873 21.8532 13.8501 21.893C13.7639 21.9851 13.6463 22.0429 13.5113 22.0429C13.3764 22.0429 13.2587 21.9851 13.1726 21.893C13.1353 21.8532 13.0857 21.8246 13.0312 21.8246C12.9766 21.8246 12.927 21.8532 12.8898 21.893C12.8036 21.9851 12.686 22.0429 12.551 22.0429C12.5487 22.0429 12.5464 22.0429 12.5441 22.0428Z" fill="#275FB2"/>
+</g>
+<g filter="url(#filter11_ii_18_6492)">
+<path d="M21.354 20.94C21.344 20.92 21.3541 20.91 21.3441 20.89C20.2541 19.03 18.234 17.77 15.914 17.77C13.594 17.77 11.5841 19.03 10.4841 20.89C10.4841 20.9 10.4841 20.91 10.4741 20.92C10.4341 21 10.4041 21.08 10.4041 21.18C10.4041 21.48 10.654 21.73 10.954 21.73C11.1086 21.73 11.2434 21.6638 11.3421 21.5584C11.3848 21.5128 11.4416 21.48 11.5041 21.48C11.5665 21.48 11.6233 21.5128 11.666 21.5584C11.7647 21.6638 11.8995 21.73 12.0541 21.73C12.2086 21.73 12.3434 21.6638 12.4421 21.5584C12.4848 21.5128 12.5416 21.48 12.604 21.48C12.6665 21.48 12.7233 21.5128 12.766 21.5584C12.8647 21.6638 12.9995 21.73 13.1541 21.73C13.3086 21.73 13.4434 21.6638 13.5421 21.5584C13.5848 21.5128 13.6416 21.48 13.7041 21.48C13.7665 21.48 13.8233 21.5128 13.866 21.5584C13.9647 21.6638 14.0995 21.73 14.2541 21.73C14.4086 21.73 14.5434 21.6638 14.6421 21.5584C14.6848 21.5128 14.7416 21.48 14.8041 21.48C14.8665 21.48 14.9233 21.5128 14.966 21.5584C15.0647 21.6638 15.1995 21.73 15.354 21.73C15.5086 21.73 15.6434 21.6638 15.7421 21.5584C15.7848 21.5128 15.8416 21.48 15.9041 21.48C15.9665 21.48 16.0233 21.5128 16.066 21.5584C16.1647 21.6638 16.2995 21.73 16.4541 21.73C16.6086 21.73 16.7434 21.6638 16.8421 21.5584C16.8848 21.5128 16.9416 21.48 17.0041 21.48C17.0665 21.48 17.1233 21.5128 17.166 21.5584C17.2647 21.6638 17.3995 21.73 17.554 21.73C17.7086 21.73 17.8434 21.6638 17.9421 21.5584C17.9848 21.5128 18.0416 21.48 18.1041 21.48C18.1665 21.48 18.2233 21.5128 18.266 21.5584C18.3647 21.6638 18.4995 21.73 18.6541 21.73C18.8086 21.73 18.9434 21.6638 19.0421 21.5584C19.0848 21.5128 19.1416 21.48 19.204 21.48C19.2665 21.48 19.3233 21.5128 19.366 21.5584C19.4647 21.6638 19.5995 21.73 19.7541 21.73C19.9086 21.73 20.0434 21.6638 20.1421 21.5584C20.1848 21.5128 20.2416 21.48 20.3041 21.48C20.3665 21.48 20.4233 21.5128 20.466 21.5584C20.5647 21.6638 20.6995 21.73 20.854 21.73C21.154 21.73 21.4041 21.48 21.4041 21.18C21.4041 21.09 21.384 21.01 21.354 20.94Z" fill="url(#paint28_linear_18_6492)"/>
+</g>
+<g filter="url(#filter12_di_18_6492)">
+<path d="M18.9141 7.24298V7.27304C18.9141 7.74399 18.7726 8.18486 18.5201 8.54559C17.904 9.37725 17.1262 10.1087 16.2272 10.6698C16.1363 10.73 16.0252 10.75 15.9141 10.75C15.803 10.75 15.6918 10.7199 15.6009 10.6698C14.712 10.0987 13.9343 9.37725 13.308 8.54559C13.0555 8.18486 12.9141 7.74399 12.9141 7.27304V7.24298C12.9242 6.41132 13.611 5.75 14.4595 5.75C14.5807 5.75 14.712 5.77004 14.8232 5.8001C15.2474 5.88026 15.611 6.1508 15.813 6.51152C15.8433 6.5516 15.8737 6.57164 15.9141 6.57164C15.9545 6.57164 15.9949 6.5516 16.0151 6.51152C16.2171 6.1508 16.5807 5.88026 17.005 5.8001C17.1161 5.77004 17.2474 5.75 17.3686 5.75C18.2272 5.75 18.9141 6.41132 18.9141 7.24298Z" fill="url(#paint29_linear_18_6492)"/>
+<path d="M18.9141 7.24298V7.27304C18.9141 7.74399 18.7726 8.18486 18.5201 8.54559C17.904 9.37725 17.1262 10.1087 16.2272 10.6698C16.1363 10.73 16.0252 10.75 15.9141 10.75C15.803 10.75 15.6918 10.7199 15.6009 10.6698C14.712 10.0987 13.9343 9.37725 13.308 8.54559C13.0555 8.18486 12.9141 7.74399 12.9141 7.27304V7.24298C12.9242 6.41132 13.611 5.75 14.4595 5.75C14.5807 5.75 14.712 5.77004 14.8232 5.8001C15.2474 5.88026 15.611 6.1508 15.813 6.51152C15.8433 6.5516 15.8737 6.57164 15.9141 6.57164C15.9545 6.57164 15.9949 6.5516 16.0151 6.51152C16.2171 6.1508 16.5807 5.88026 17.005 5.8001C17.1161 5.77004 17.2474 5.75 17.3686 5.75C18.2272 5.75 18.9141 6.41132 18.9141 7.24298Z" fill="url(#paint30_radial_18_6492)"/>
+<path d="M18.9141 7.24298V7.27304C18.9141 7.74399 18.7726 8.18486 18.5201 8.54559C17.904 9.37725 17.1262 10.1087 16.2272 10.6698C16.1363 10.73 16.0252 10.75 15.9141 10.75C15.803 10.75 15.6918 10.7199 15.6009 10.6698C14.712 10.0987 13.9343 9.37725 13.308 8.54559C13.0555 8.18486 12.9141 7.74399 12.9141 7.27304V7.24298C12.9242 6.41132 13.611 5.75 14.4595 5.75C14.5807 5.75 14.712 5.77004 14.8232 5.8001C15.2474 5.88026 15.611 6.1508 15.813 6.51152C15.8433 6.5516 15.8737 6.57164 15.9141 6.57164C15.9545 6.57164 15.9949 6.5516 16.0151 6.51152C16.2171 6.1508 16.5807 5.88026 17.005 5.8001C17.1161 5.77004 17.2474 5.75 17.3686 5.75C18.2272 5.75 18.9141 6.41132 18.9141 7.24298Z" fill="url(#paint31_radial_18_6492)"/>
+<path d="M18.9141 7.24298V7.27304C18.9141 7.74399 18.7726 8.18486 18.5201 8.54559C17.904 9.37725 17.1262 10.1087 16.2272 10.6698C16.1363 10.73 16.0252 10.75 15.9141 10.75C15.803 10.75 15.6918 10.7199 15.6009 10.6698C14.712 10.0987 13.9343 9.37725 13.308 8.54559C13.0555 8.18486 12.9141 7.74399 12.9141 7.27304V7.24298C12.9242 6.41132 13.611 5.75 14.4595 5.75C14.5807 5.75 14.712 5.77004 14.8232 5.8001C15.2474 5.88026 15.611 6.1508 15.813 6.51152C15.8433 6.5516 15.8737 6.57164 15.9141 6.57164C15.9545 6.57164 15.9949 6.5516 16.0151 6.51152C16.2171 6.1508 16.5807 5.88026 17.005 5.8001C17.1161 5.77004 17.2474 5.75 17.3686 5.75C18.2272 5.75 18.9141 6.41132 18.9141 7.24298Z" fill="url(#paint32_radial_18_6492)"/>
+</g>
+<g filter="url(#filter13_f_18_6492)">
+<path d="M15.758 4.25683H15.9184C18.7423 4.25683 21.0316 6.40927 21.0316 9.06444V10.4641C21.0316 10.818 21.2343 11.1273 21.5366 11.2951V8.16988C21.5366 5.16944 18.9847 2.74005 15.8331 2.74005C12.6815 2.74005 10.1296 5.16944 10.1296 8.16988V11.3006C10.4375 11.1342 10.6448 10.8219 10.6448 10.4641V9.06444C10.6448 6.40927 12.934 4.25683 15.758 4.25683Z" fill="#B24340"/>
+</g>
+<g filter="url(#filter14_f_18_6492)">
+<path d="M15.7551 3.67289H15.9216C18.8522 3.67289 21.2279 5.90501 21.2279 8.65848V10.1099C21.2279 10.4769 21.4383 10.7977 21.752 10.9717V8.05395C21.752 4.94243 19.1038 2.4231 15.8331 2.4231C12.5624 2.4231 9.91418 4.94243 9.91418 8.05395V10.9775C10.2337 10.8049 10.4488 10.481 10.4488 10.1099V8.65848C10.4488 5.90502 12.8245 3.67289 15.7551 3.67289Z" fill="#741019"/>
+</g>
+<g filter="url(#filter15_ii_18_6492)">
+<path d="M15.9238 3.59688H15.7523C12.7337 3.59688 10.2867 6.04392 10.2867 9.06251V10.75C10.2867 11.3023 9.83895 11.75 9.28667 11.75H2.44595C2.11458 11.75 1.84595 11.4814 1.84595 11.15V11.0175C1.84595 9.22261 3.30103 7.76753 5.09595 7.76753H8.39269C8.51369 7.76753 8.6169 7.68052 8.64176 7.56211C9.3331 4.26931 12.254 1.79688 15.7523 1.79688H15.9238C19.4221 1.79688 22.343 4.26931 23.0343 7.56211C23.0592 7.68052 23.1624 7.76753 23.2834 7.76753H26.5801C28.3751 7.76753 29.8301 9.22261 29.8301 11.0175V11.15C29.8301 11.4814 29.5615 11.75 29.2301 11.75H22.3894C21.8371 11.75 21.3894 11.3023 21.3894 10.75V9.0625C21.3894 6.04392 18.9424 3.59688 15.9238 3.59688Z" fill="url(#paint33_radial_18_6492)"/>
+<path d="M15.9238 3.59688H15.7523C12.7337 3.59688 10.2867 6.04392 10.2867 9.06251V10.75C10.2867 11.3023 9.83895 11.75 9.28667 11.75H2.44595C2.11458 11.75 1.84595 11.4814 1.84595 11.15V11.0175C1.84595 9.22261 3.30103 7.76753 5.09595 7.76753H8.39269C8.51369 7.76753 8.6169 7.68052 8.64176 7.56211C9.3331 4.26931 12.254 1.79688 15.7523 1.79688H15.9238C19.4221 1.79688 22.343 4.26931 23.0343 7.56211C23.0592 7.68052 23.1624 7.76753 23.2834 7.76753H26.5801C28.3751 7.76753 29.8301 9.22261 29.8301 11.0175V11.15C29.8301 11.4814 29.5615 11.75 29.2301 11.75H22.3894C21.8371 11.75 21.3894 11.3023 21.3894 10.75V9.0625C21.3894 6.04392 18.9424 3.59688 15.9238 3.59688Z" fill="url(#paint34_radial_18_6492)"/>
+</g>
+<g filter="url(#filter16_f_18_6492)">
+<path d="M17.4614 12.5156L17.4614 16" stroke="#EC4287" stroke-width="0.25" stroke-linecap="round"/>
+</g>
+<g filter="url(#filter17_f_18_6492)">
+<path d="M14.4927 12.5156L14.4927 16" stroke="#F83B5D" stroke-width="0.25" stroke-linecap="round"/>
+</g>
+<g filter="url(#filter18_f_18_6492)">
+<path d="M14.4771 14.1562H17.2896" stroke="url(#paint35_linear_18_6492)" stroke-width="0.25" stroke-linecap="round"/>
+</g>
+<g filter="url(#filter19_f_18_6492)">
+<path d="M16.8364 18.3281C17.8052 18.4375 19.8052 19.15 20.8677 21.0625" stroke="url(#paint36_radial_18_6492)" stroke-width="0.25" stroke-linecap="round"/>
+</g>
+<g filter="url(#filter20_f_18_6492)">
+<path d="M12.6702 3.46879C13.4056 2.99813 15.4281 2.28408 17.6782 3.00549C20.5683 3.93209 22.1568 6.07209 22.2891 8.71951" stroke="url(#paint37_radial_18_6492)" stroke-width="0.8" stroke-linecap="round"/>
+</g>
+<defs>
+<filter id="filter0_i_18_6492" x="4.66406" y="13.75" width="3.25" height="4.25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.25" dy="0.25"/>
+<feGaussianBlur stdDeviation="0.375"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0705882 0 0 0 0 0.466667 0 0 0 0 0.815686 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_6492"/>
+</filter>
+<filter id="filter1_i_18_6492" x="4.66406" y="20.75" width="3.25" height="4.25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.25" dy="0.25"/>
+<feGaussianBlur stdDeviation="0.375"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0705882 0 0 0 0 0.466667 0 0 0 0 0.815686 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_6492"/>
+</filter>
+<filter id="filter2_i_18_6492" x="23.6641" y="13.75" width="3.25" height="4.25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.25" dy="0.25"/>
+<feGaussianBlur stdDeviation="0.375"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0705882 0 0 0 0 0.466667 0 0 0 0 0.815686 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_6492"/>
+</filter>
+<filter id="filter3_i_18_6492" x="23.6641" y="20.75" width="3.25" height="4.25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.25" dy="0.25"/>
+<feGaussianBlur stdDeviation="0.375"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0705882 0 0 0 0 0.466667 0 0 0 0 0.815686 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_6492"/>
+</filter>
+<filter id="filter4_f_18_6492" x="13.1757" y="11.4161" width="5" height="5.90399" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.25" result="effect1_foregroundBlur_18_6492"/>
+</filter>
+<filter id="filter5_ii_18_6492" x="13.9141" y="11.5" width="4.25" height="5.25" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.25"/>
+<feGaussianBlur stdDeviation="0.2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.788235 0 0 0 0 0.0784314 0 0 0 0 0.317647 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_6492"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="-0.25"/>
+<feGaussianBlur stdDeviation="0.125"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.788235 0 0 0 0 0.0745098 0 0 0 0 0.313726 0 0 0 1 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_18_6492" result="effect2_innerShadow_18_6492"/>
+</filter>
+<filter id="filter6_f_18_6492" x="11.1703" y="19.7601" width="9.48755" height="3.03204" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.25" result="effect1_foregroundBlur_18_6492"/>
+</filter>
+<filter id="filter7_ii_18_6492" x="12.1188" y="19.7501" width="3.48596" height="8.58905" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3"/>
+<feGaussianBlur stdDeviation="0.15"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0745098 0 0 0 0 0.466667 0 0 0 0 0.827451 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_6492"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.2"/>
+<feGaussianBlur stdDeviation="0.1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.270588 0 0 0 0 0.682353 0 0 0 0 1 0 0 0 1 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_18_6492" result="effect2_innerShadow_18_6492"/>
+</filter>
+<filter id="filter8_ii_18_6492" x="16.1211" y="19.7501" width="3.48596" height="8.58905" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3"/>
+<feGaussianBlur stdDeviation="0.15"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0745098 0 0 0 0 0.466667 0 0 0 0 0.827451 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_6492"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.2"/>
+<feGaussianBlur stdDeviation="0.1"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.270588 0 0 0 0 0.682353 0 0 0 0 1 0 0 0 1 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_18_6492" result="effect2_innerShadow_18_6492"/>
+</filter>
+<filter id="filter9_f_18_6492" x="16.0464" y="19.6814" width="3.73535" height="2.86145" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.25" result="effect1_foregroundBlur_18_6492"/>
+</filter>
+<filter id="filter10_f_18_6492" x="12.0441" y="19.6814" width="3.73535" height="2.86145" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.25" result="effect1_foregroundBlur_18_6492"/>
+</filter>
+<filter id="filter11_ii_18_6492" x="10.4041" y="17.62" width="11.25" height="4.31002" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.25" dy="-0.15"/>
+<feGaussianBlur stdDeviation="0.2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.737255 0 0 0 0 0.172549 0 0 0 0 0.254902 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_6492"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.25" dy="0.2"/>
+<feGaussianBlur stdDeviation="0.25"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.737255 0 0 0 0 0.172549 0 0 0 0 0.254902 0 0 0 1 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_18_6492" result="effect2_innerShadow_18_6492"/>
+</filter>
+<filter id="filter12_di_18_6492" x="12.1141" y="5.55" width="7.55" height="6" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-0.3" dy="0.3"/>
+<feGaussianBlur stdDeviation="0.25"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.772549 0 0 0 0 0.376471 0 0 0 0 0.396078 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_18_6492"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_18_6492" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.8" dy="-0.1"/>
+<feGaussianBlur stdDeviation="0.375"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.74902 0 0 0 0 0.137255 0 0 0 0 0.254902 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_18_6492"/>
+</filter>
+<filter id="filter13_f_18_6492" x="9.12964" y="1.74005" width="13.407" height="10.5606" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.5" result="effect1_foregroundBlur_18_6492"/>
+</filter>
+<filter id="filter14_f_18_6492" x="9.31418" y="1.8231" width="13.0378" height="9.75438" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.3" result="effect1_foregroundBlur_18_6492"/>
+</filter>
+<filter id="filter15_ii_18_6492" x="1.84595" y="1.29688" width="28.4841" height="10.8531" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="-0.5"/>
+<feGaussianBlur stdDeviation="0.25"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.772549 0 0 0 0 0.141176 0 0 0 0 0.243137 0 0 0 1 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_18_6492"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="0.5" dy="0.4"/>
+<feGaussianBlur stdDeviation="0.375"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.65098 0 0 0 0 0.2 0 0 0 0 0.294118 0 0 0 1 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_18_6492" result="effect2_innerShadow_18_6492"/>
+</filter>
+<filter id="filter16_f_18_6492" x="16.9864" y="12.0406" width="0.95" height="4.43437" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.175" result="effect1_foregroundBlur_18_6492"/>
+</filter>
+<filter id="filter17_f_18_6492" x="14.0177" y="12.0406" width="0.95" height="4.43437" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.175" result="effect1_foregroundBlur_18_6492"/>
+</filter>
+<filter id="filter18_f_18_6492" x="14.0021" y="13.6813" width="3.7625" height="0.95" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.175" result="effect1_foregroundBlur_18_6492"/>
+</filter>
+<filter id="filter19_f_18_6492" x="16.4614" y="17.9531" width="4.78125" height="3.48438" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.125" result="effect1_foregroundBlur_18_6492"/>
+</filter>
+<filter id="filter20_f_18_6492" x="11.4701" y="1.49822" width="12.0189" height="8.42129" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.4" result="effect1_foregroundBlur_18_6492"/>
+</filter>
+<linearGradient id="paint0_linear_18_6492" x1="11.5222" y1="21.235" x2="7.12176" y2="21.235" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C15953"/>
+<stop offset="1" stop-color="#C15953" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_18_6492" x1="7.12176" y1="11.3341" x2="7.12176" y2="13.8728" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C15953"/>
+<stop offset="1" stop-color="#C15953" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint2_linear_18_6492" x1="2.8833" y1="20.996" x2="4.01296" y2="20.996" gradientUnits="userSpaceOnUse">
+<stop stop-color="#BE8A79"/>
+<stop offset="1" stop-color="#BE8A79" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint3_linear_18_6492" x1="22.4417" y1="9.83002" x2="22.4417" y2="22.3942" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FD937F"/>
+<stop offset="1" stop-color="#FFB39C"/>
+</linearGradient>
+<linearGradient id="paint4_linear_18_6492" x1="28.8833" y1="19.785" x2="26.5991" y2="19.785" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFD2AD"/>
+<stop offset="1" stop-color="#FFD2AD" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint5_linear_18_6492" x1="29.2553" y1="20.3107" x2="28.5593" y2="20.3107" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFAE98"/>
+<stop offset="1" stop-color="#FFAE98" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint6_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(23.5831 10.1579) rotate(147.475) scale(10.5778 5.06583)">
+<stop offset="0.10017" stop-color="#C25251"/>
+<stop offset="1" stop-color="#C25251" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint7_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(28.8833 11.1406) rotate(158.429) scale(2.8899 0.978174)">
+<stop offset="0.177782" stop-color="#B56057"/>
+<stop offset="0.987654" stop-color="#B56057" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint8_linear_18_6492" x1="15.8381" y1="11.2474" x2="15.8381" y2="29.7401" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFB193"/>
+<stop offset="1" stop-color="#FFD2AE"/>
+</linearGradient>
+<linearGradient id="paint9_linear_18_6492" x1="10.272" y1="24.8958" x2="13.5339" y2="24.8958" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CD897B"/>
+<stop offset="1" stop-color="#CD897B" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint10_linear_18_6492" x1="21.7411" y1="18.3371" x2="19.1301" y2="18.3371" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFCFAA"/>
+<stop offset="1" stop-color="#FFCFAA" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint11_linear_18_6492" x1="5.0716" y1="17.75" x2="7.57016" y2="13.7438" gradientUnits="userSpaceOnUse">
+<stop stop-color="#47CAFF"/>
+<stop offset="1" stop-color="#3892E6"/>
+</linearGradient>
+<linearGradient id="paint12_linear_18_6492" x1="4.91406" y1="15.75" x2="5.73138" y2="15.75" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5ADFFF"/>
+<stop offset="0.90937" stop-color="#5ADFFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint13_linear_18_6492" x1="5.0716" y1="24.75" x2="7.57016" y2="20.7438" gradientUnits="userSpaceOnUse">
+<stop stop-color="#47CAFF"/>
+<stop offset="1" stop-color="#3892E6"/>
+</linearGradient>
+<linearGradient id="paint14_linear_18_6492" x1="4.91406" y1="22.75" x2="5.73138" y2="22.75" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5ADFFF"/>
+<stop offset="0.90937" stop-color="#5ADFFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint15_linear_18_6492" x1="24.0716" y1="17.75" x2="26.5702" y2="13.7438" gradientUnits="userSpaceOnUse">
+<stop stop-color="#47CAFF"/>
+<stop offset="1" stop-color="#3892E6"/>
+</linearGradient>
+<linearGradient id="paint16_linear_18_6492" x1="23.9141" y1="15.75" x2="24.7314" y2="15.75" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5ADFFF"/>
+<stop offset="0.90937" stop-color="#5ADFFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint17_linear_18_6492" x1="24.0716" y1="24.75" x2="26.5702" y2="20.7438" gradientUnits="userSpaceOnUse">
+<stop stop-color="#47CAFF"/>
+<stop offset="1" stop-color="#3892E6"/>
+</linearGradient>
+<linearGradient id="paint18_linear_18_6492" x1="23.9141" y1="22.75" x2="24.7314" y2="22.75" gradientUnits="userSpaceOnUse">
+<stop stop-color="#5ADFFF"/>
+<stop offset="0.90937" stop-color="#5ADFFF" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint19_linear_18_6492" x1="14.422" y1="14.25" x2="17.5552" y2="14.25" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E22A4D"/>
+<stop offset="1" stop-color="#DA3178"/>
+</linearGradient>
+<linearGradient id="paint20_linear_18_6492" x1="15.9141" y1="21.5268" x2="15.9141" y2="30.1607" gradientUnits="userSpaceOnUse">
+<stop stop-color="#DB946D"/>
+<stop offset="1" stop-color="#FFCCAD"/>
+</linearGradient>
+<linearGradient id="paint21_linear_18_6492" x1="11.4609" y1="26.0682" x2="12.1262" y2="26.0682" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A57364"/>
+<stop offset="1" stop-color="#A57364" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint22_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(11.4609 21.0785) rotate(64.861) scale(2.5567 2.35921)">
+<stop stop-color="#A85540"/>
+<stop offset="1" stop-color="#A85540" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint23_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(20.0317 21.334) rotate(58.8968) scale(0.649453 1.19116)">
+<stop stop-color="#A85540"/>
+<stop offset="1" stop-color="#A85540" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint24_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(20.3672 30.5169) rotate(-90) scale(7.42451 0.819829)">
+<stop stop-color="#FFF1C0"/>
+<stop offset="1" stop-color="#FFF1C0" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint25_linear_18_6492" x1="15.9141" y1="21.5425" x2="15.9141" y2="22.5887" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A43D3B"/>
+<stop offset="1" stop-color="#A43D3B" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint26_linear_18_6492" x1="13.9118" y1="20.875" x2="13.9118" y2="28.3391" gradientUnits="userSpaceOnUse">
+<stop stop-color="#348FE8"/>
+<stop offset="1" stop-color="#36A1FE"/>
+</linearGradient>
+<linearGradient id="paint27_linear_18_6492" x1="17.9141" y1="20.875" x2="17.9141" y2="28.3391" gradientUnits="userSpaceOnUse">
+<stop stop-color="#348FE8"/>
+<stop offset="1" stop-color="#36A1FE"/>
+</linearGradient>
+<linearGradient id="paint28_linear_18_6492" x1="15.9041" y1="17.77" x2="15.9041" y2="21.73" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E33981"/>
+<stop offset="1" stop-color="#EA2653"/>
+</linearGradient>
+<linearGradient id="paint29_linear_18_6492" x1="15.9141" y1="5.75" x2="15.9141" y2="10.4703" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E93178"/>
+<stop offset="1" stop-color="#E41D4A"/>
+</linearGradient>
+<radialGradient id="paint30_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(16.352 6.03123) rotate(-60.4221) scale(1.3295 0.799095)">
+<stop stop-color="#BC2E4F"/>
+<stop offset="1" stop-color="#BC2E4F" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint31_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(18.9141 6.56248) rotate(138.957) scale(2.2368 3.01638)">
+<stop stop-color="#FF4D84"/>
+<stop offset="1" stop-color="#FF4D84" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint32_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(14.9614 6.90623) rotate(142.765) scale(0.98127 1.32327)">
+<stop stop-color="#FF4D84"/>
+<stop offset="1" stop-color="#FF4D84" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint33_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(18.4504 2.36565) rotate(105.556) scale(9.74117 27.3883)">
+<stop stop-color="#DB377F"/>
+<stop offset="1" stop-color="#EE3455"/>
+</radialGradient>
+<radialGradient id="paint34_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(29.8301 9.07246) rotate(153.801) scale(2.79837 6.98239)">
+<stop stop-color="#FF5371"/>
+<stop offset="1" stop-color="#FF5371" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="paint35_linear_18_6492" x1="14.8521" y1="14.1563" x2="16.8521" y2="14.1562" gradientUnits="userSpaceOnUse">
+<stop stop-color="#F83B5D"/>
+<stop offset="1" stop-color="#F83B5D" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint36_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(19.2427 18.9844) rotate(117.613) scale(1.14618 2.86949)">
+<stop stop-color="#F33C7F"/>
+<stop offset="1" stop-color="#F33C7F" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="paint37_radial_18_6492" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(20.6566 3.38054) rotate(138.468) scale(4.12598 6.66631)">
+<stop stop-color="#ED4383"/>
+<stop offset="1" stop-color="#FF4C76" stop-opacity="0"/>
+</radialGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## Summary

Adds eight cards to the seed deck in all five locales (fr, en, de, it, es), four per pile with one foil each:

- home-071 "Doublage sauvage" (movie on mute, improvised dialogue)
- home-072 "Plaidoirie absurde" (defend a ridiculous cause like a lawyer)
- home-073 "Vacances virtuelles" (plan an imaginary trip on Street View)
- home-074 "Loterie des envies" (foil, draw one of three written desires)
- out-076 "Errance à pile ou face" (a coin decides every turn of the walk)
- out-077 "Fous rires interdits" (make each other laugh silently at the library)
- out-078 "Bambi sur glace" (ice rink duo)
- out-079 "Amants de passage" (foil, daytime hotel room)

Also bundles three new Fluent UI Color emoji SVGs (`desert-island`, `ice-skate`, `love-hotel`) and updates the foil draw-rate figures in `docs/architecture.md` (27 foil out of 147, around 9.2% home and 3.9% outdoor, still under the 10% target).

## Expected behaviors

- Fresh installs seed 147 cards per locale; id, pile, foil, and emoji stay identical across locales, so the boot-time seed validation passes.
- Existing instances receive the new cards after an admin deck sync (both "Full mirror" and "Add and update" add them).
- The new emoji render on the draw screen and in Collection; deck emoji are cached at runtime by the service worker, so no shell precache or version change is needed.

## Merge order

Based on #108 (the deck cleanup); merge #108 first, GitHub then retargets this PR to `main` automatically.
