### PR TITLE
chore(release): cut version 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-07-06
+
 ### Added
 
 - The History screen gains filter chips (pile, returned, banned) and a summary line with the total number of draws and bans.
 - The Collection gains two filters: "Banned" to find banned cards without scanning the grid, and "Undiscovered" to see what is left to find.
 - The admin Users tab can rename an account.
-- Eight new cards join the seed deck, four per pile with one foil each: improvised movie dubbing, absurd courtroom pleas, virtual vacation planning, and a desire lottery at home; coin-flip wandering, library giggle duels, ice skating, and a daytime hotel escapade outdoors. Three new emoji are bundled for them (desert island, ice skate, love hotel).
+- Eight new cards join the seed deck, four per pile with one foil each, from improvised movie dubbing to a daytime hotel escapade. Three new emoji are bundled for them (desert island, ice skate, love hotel).
 
 ### Changed
 
 - The revealed card's idle shine now sweeps the whole face as a soft golden glint, and the card sits visually centered between the title and the action buttons.
-- The bad-singing card "Lyrical massacre" is reworked into "Lip-sync battle" so it no longer tells the same joke as the living-room karaoke card, and the English deck drops its last British spellings for US English.
-- A quality pass over the existing deck: four flat titles gain the deck's deadpan voice (museum, aquarium, karting, school quiz), four descriptions land their punchline better (waterside walk, submission, couple quiz, junk drawer), and the ephemeral-tattoos card gets its own lipstick emoji instead of sharing the kiss mark with the hickeys card.
+- A quality pass over the existing deck: the second bad-singing card becomes a lip-sync battle, four flat titles gain the deck's deadpan voice, four descriptions land their punchline better, the ephemeral-tattoos card gets its own lipstick emoji, and the English deck drops its last British spellings for US English.
 
 ### Removed
 
-- Four near-duplicate cards leave the seed deck: the second car-in-the-woods escapade, the generic outdoor-thrill card, the second racy photo shoot, and the "Food truck" card that told the same joke as "Street gastronomy". Instances that already seeded keep them until an admin applies a "Full mirror" deck sync.
+- Four near-duplicate cards leave the seed deck (two outdoor thrills, a second racy photo shoot, a second street-food outing). Instances that already seeded keep them until an admin applies a "Full mirror" deck sync.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/compress": "^9.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "private": true,
   "type": "module",
   "description": "Couplecards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

Cuts version 1.13.0: bumps the root and server `package.json` (and both lockfiles, top-level entries only), and promotes `[Unreleased]` to `[1.13.0] - 2026-07-06` in the CHANGELOG with the usual tightening pass.

Minor bump: the cycle ships new user-visible features (History filter chips, Collection filters, admin account rename, eight new deck cards) plus the deck cleanup and a fix.

## Expected behaviors

- `npm ci` accepts both lockfiles (only the top-level `version` keys changed).
- Once the `v1.13.0` tag is pushed after merge, the Release workflow builds and publishes `ghcr.io/qiaeru/couplecards:v1.13.0` and `:latest`.
