### PR TITLE
refactor(ui): reduce password-strength to its single entry point

### DIFF
--- a/public/js/ui/password-strength.js
+++ b/public/js/ui/password-strength.js
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
-// Password strength component. Uses Lit when available; falls back to vanilla
-// DOM if the vendor bundle has not been produced yet. zxcvbn is lazy-loaded
-// only on pages that actually use password inputs.
+// Password strength component: a strength bar plus a live checklist of the
+// hard rules, bound to a password input. zxcvbn is lazy-loaded only on pages
+// that carry a password field; when the vendor bundle is missing the checklist
+// keeps working and only the score stays at zero.
 
 import { t } from '../core/i18n.js';
 
 let zxcvbnPromise = null;
 
-export async function loadZxcvbn() {
+async function loadZxcvbn() {
   if (zxcvbnPromise) return zxcvbnPromise;
   zxcvbnPromise = import('/vendor/zxcvbn.js').catch((err) => {
     console.warn('zxcvbn bundle not available, scoring disabled', err);
@@ -17,7 +18,7 @@ export async function loadZxcvbn() {
 }
 
 // Hard rules mirrored from the backend `lib/password.js`.
-export const RULES = {
+const RULES = {
   minLength: 12,
   requireUpper: true,
   requireLower: true,
@@ -26,7 +27,7 @@ export const RULES = {
   noWhitespace: true,
 };
 
-export function evaluateHardRules(password, username = '') {
+function evaluateHardRules(password, username = '') {
   return {
     minLength: password.length >= RULES.minLength,
     upper: /[A-Z]/.test(password),
@@ -38,7 +39,7 @@ export function evaluateHardRules(password, username = '') {
   };
 }
 
-export async function computeScore(password, userInputs = []) {
+async function computeScore(password, userInputs = []) {
   const mod = await loadZxcvbn();
   if (!mod || !password) return { score: 0, feedback: { warning: '', suggestions: [] } };
   const result = mod.zxcvbn(password, userInputs.filter(Boolean));

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
 // behind, since the page got the stale copy while the revalidation stored the
 // fresh one, and left the admin card list one edit behind for good.
 
-const VERSION = 'couplecards-v56';
+const VERSION = 'couplecards-v57';
 const SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
Follow-up to #130, closing the one item that sweep deliberately left open.

## Scope

`bindPasswordStrength` is the only symbol `login.js`, `register.js` and `settings.js` import from this module. `loadZxcvbn`, `RULES`, `evaluateHardRules` and `computeScore` exist solely to serve it, so they lose the `export` keyword and keep working exactly as before. The module now declares one entry point, which is what it actually offers, and matches the treatment the other ten internal-only functions got in #130.

The file header also described a component built on Lit with a vanilla DOM fallback. Lit appears nowhere in the repository and the vendor bundle carries only zxcvbn and fflate, so that comment pointed readers at a code path that never existed. It now describes what the component does and what happens when the vendor bundle is absent.

No behavior changes: removing an `export` keyword cannot affect how a module's own code runs.

## Expected behavior after merge

- The strength bar and rule checklist behave identically on the sign-in, registration and change-password screens.
- With the vendor bundle missing, the checklist still evaluates the hard rules and only the zxcvbn score stays at zero, as before.

## Validation

The module served over HTTP exposes `bindPasswordStrength` and nothing else, and no longer mentions Lit. Every import in the tree was checked to still resolve to a real export, every JS module was syntax-checked, and the server was run through the same 33 HTTP checks as #130 with the same result: 32 pass, the lone failure being the intended 403 on `POST /api/state/reset` for the read-only demo account. The pages that mount the component (`/login.html`, `/register.html`) and their entry points all serve correctly.
