### PR TITLE
chore(release): cut version 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-08-24
+
 ### Added
 
 - A pile that runs out now explains itself: a notice under the piles says whether every card is banned, with a button opening the Collection on that filter, or whether the deck simply holds no card for that pile.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "MIT",
       "devDependencies": {
         "@zxcvbn-ts/core": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "A self-hosted web app that lets couples draw activity cards to break the routine and spice up their daily lives.",
   "private": true,
   "type": "module",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "couplecards-server",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "couplecards-server",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/compress": "^9.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "couplecards-server",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "type": "module",
   "description": "Couplecards backend — Fastify + node:sqlite",


### PR DESCRIPTION
## Summary

Cuts version 1.14.0. Minor bump: the release carries a new user-visible feature, the notice that explains an empty pile and offers a way out of it.

## Scope

Version bumped to `1.14.0` in `package.json`, `server/package.json` and both lockfiles. `[Unreleased]` promoted to `## [1.14.0] - 2026-08-24`, with a fresh empty `[Unreleased]` above it. No code change.

## Release contents

**Added.** A pile that runs out now says whether every card is banned, with a button opening the Collection on that filter, or whether the deck simply holds no card for that pile.

**Changed.** The Collection screen renders only the cards in view and stops animating the halo on undiscovered rare cards. The deck is downloaded in one language rather than five, taking the bundled deck from 115 KB to 39 KB. The deck, the per-user state and the interface translations load in parallel at startup.

**Fixed.** A card edited in the admin panel reaches players on their next launch. Signing out clears the deck, bans and history cached on the device. The admin card editor suggests the desert island, ice skate and love hotel emoji.

## Expected behaviors after merge

- Pushing the `v1.14.0` tag triggers the Release workflow, which builds and pushes the multi-arch image to `ghcr.io/qiaeru/couplecards:v1.14.0` and `:latest`.
- `/api/health` keeps reporting liveness only; the version is not exposed publicly.
