### PR TITLE
chore: point the developer link at qiaeru.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- The developer link in the sign-in footer now points to qiaeru.com, the site's new address.
+
 ## [1.14.0] - 2026-08-24
 
 ### Added

--- a/public/css/auth.css
+++ b/public/css/auth.css
@@ -90,7 +90,7 @@ body { font-family: var(--font); }
 }
 .auth-footer-sep { opacity: 0.45; }
 
-/* qiae.ru lockup: the head sits on an organic orange blob, mirroring the source
+/* qiaeru.com lockup: the head sits on an organic orange blob, mirroring the source
    site (CSS blob, not part of the SVG). */
 .qiaeru-logo {
   position: relative;

--- a/public/forgot-password.html
+++ b/public/forgot-password.html
@@ -34,7 +34,7 @@
     </section>
     <footer class="auth-footer">
       <span data-i18n="footer.developedBy">Developed by</span>
-      <a class="auth-footer-link" href="https://qiae.ru" target="_blank" rel="noopener noreferrer">
+      <a class="auth-footer-link" href="https://qiaeru.com" target="_blank" rel="noopener noreferrer">
         <span class="qiaeru-logo"><img class="auth-footer-logo" src="/icons/qiaeru.svg" alt="Qiaeru" width="22" height="22" draggable="false"></span>
       </a>
       <span class="auth-footer-sep" aria-hidden="true">|</span>

--- a/public/login.html
+++ b/public/login.html
@@ -75,7 +75,7 @@
 
     <footer class="auth-footer">
       <span data-i18n="footer.developedBy">Developed by</span>
-      <a class="auth-footer-link" href="https://qiae.ru" target="_blank" rel="noopener noreferrer">
+      <a class="auth-footer-link" href="https://qiaeru.com" target="_blank" rel="noopener noreferrer">
         <span class="qiaeru-logo"><img class="auth-footer-logo" src="/icons/qiaeru.svg" alt="Qiaeru" width="22" height="22" draggable="false"></span>
       </a>
       <span class="auth-footer-sep" aria-hidden="true">|</span>

--- a/public/register.html
+++ b/public/register.html
@@ -62,7 +62,7 @@
 
     <footer class="auth-footer">
       <span data-i18n="footer.developedBy">Developed by</span>
-      <a class="auth-footer-link" href="https://qiae.ru" target="_blank" rel="noopener noreferrer">
+      <a class="auth-footer-link" href="https://qiaeru.com" target="_blank" rel="noopener noreferrer">
         <span class="qiaeru-logo"><img class="auth-footer-logo" src="/icons/qiaeru.svg" alt="Qiaeru" width="22" height="22" draggable="false"></span>
       </a>
       <span class="auth-footer-sep" aria-hidden="true">|</span>

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,7 @@
 // behind, since the page got the stale copy while the revalidation stored the
 // fresh one, and left the admin card list one edit behind for good.
 
-const VERSION = 'couplecards-v58';
+const VERSION = 'couplecards-v59';
 const SHELL = [
   '/',
   '/index.html',


### PR DESCRIPTION
The developer link in the auth footer still pointed at the old `qiae.ru` domain. It now points at `qiaeru.com`.

## Scope

- `public/login.html`, `public/register.html`, `public/forgot-password.html`: the footer `href`.
- `public/css/auth.css`: a comment that named the old domain.
- `public/sw.js`: version bump so clients pick up the changed static files.

No other reference to the old domain remains in the tree. The GitHub and registry URLs (`github.com/qiaeru`, `ghcr.io/qiaeru`) and the demo host `couplecards.qiaeru.com` were already correct and are untouched.

## Expected behavior after merge

- Clicking the Qiaeru logo under the sign-in, sign-up and forgot-password forms opens `https://qiaeru.com` in a new tab.
- Returning visitors get the updated pages after the Service Worker refreshes its cache.
