### PR TITLE
fix(server): drop the deprecated Fastify logging option, and tighten the emoji check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - The developer link in the sign-in footer now points to qiaeru.com, the site's new address.
 - The repository now ships ESLint, Prettier, five repo consistency checks and a server test suite, all run by CI on every pull request. Running an instance is unaffected: `docker compose up` needs none of them.
+- The server configures its request logging through the interface Fastify 6 will require, instead of the option that release removes. Production keeps skipping the per-request access log line, and a future Fastify upgrade can no longer turn that noise back on unnoticed.
 
 ## [1.14.0] - 2026-08-24
 

--- a/scripts/checks/cards.mjs
+++ b/scripts/checks/cards.mjs
@@ -9,7 +9,17 @@
 // back to English, and every emoji slug needs its SVG or the card renders with
 // a hole where the icon should be.
 
-import { repoPath, readJson, existsExact, walk, rel } from './lib.mjs';
+import { repoPath, readJson, read, existsExact, walk, rel } from './lib.mjs';
+
+// The slug list the admin autocomplete offers. Read as text rather than
+// imported, because the module sits in a browser bundle and importing it would
+// drag the feature module's own imports into this script.
+function adminSlugs() {
+  const source = read(repoPath('public', 'js', 'features', 'admin', 'emoji-slugs.js'));
+  const match = source.match(/EMOJI_SLUGS\s*=\s*\[([\s\S]*?)\]/);
+  if (!match) return null;
+  return [...match[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+}
 
 // Best-effort explanation for an INVALID_DECK: the structural fields of a card
 // must be identical in every locale file, and that mismatch is the failure
@@ -96,11 +106,34 @@ export async function run() {
     );
   }
 
-  // Slugs the app draws itself (piles, hearts) are never on a card, so an
-  // unused SVG is reported rather than failed: it may be deliberate.
-  const orphans = [...available].filter((slug) => !used.has(slug));
-  if (orphans.length > 0) {
-    notes.push(`${orphans.length} emoji SVG(s) not used by any card: ${orphans.join(', ')}`);
+  // The admin form's autocomplete reads EMOJI_SLUGS, so an icon absent from
+  // that list is invisible to whoever edits a card: it ships, it renders on the
+  // cards that already reference it, and nobody can pick it. That is exactly
+  // how the desert island, ice skate and love hotel icons stayed unreachable
+  // between 1.13.0 and 1.14.0. The list must mirror the directory both ways.
+  const listed = adminSlugs();
+  if (listed === null) {
+    errors.push('could not read EMOJI_SLUGS from public/js/features/admin/emoji-slugs.js');
+  } else {
+    const unreachable = [...available].filter((slug) => !listed.includes(slug));
+    if (unreachable.length > 0) {
+      errors.push(
+        `${unreachable.length} emoji SVG(s) missing from the admin autocomplete list, so no card can be given them: ${unreachable.join(', ')}`,
+      );
+    }
+    const phantom = listed.filter((slug) => !available.has(slug));
+    if (phantom.length > 0) {
+      errors.push(
+        `${phantom.length} slug(s) offered by the admin autocomplete have no SVG: ${phantom.join(', ')}`,
+      );
+    }
+    const sorted = [...listed].sort();
+    if (listed.join(',') !== sorted.join(',')) {
+      errors.push('EMOJI_SLUGS is not alphabetically sorted, which its own comment promises');
+    }
+    if (unreachable.length === 0 && phantom.length === 0) {
+      notes.push(`${available.size} emoji icons, all reachable from the admin form`);
+    }
   }
 
   const counts = {};

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -3,7 +3,7 @@
 // routes. Kept apart from index.js so the tests can build an app and drive it
 // through app.inject() without opening a port or installing signal handlers.
 
-import Fastify from 'fastify';
+import Fastify, { LogController } from 'fastify';
 import compressPlugin from '@fastify/compress';
 import { config } from './config.js';
 
@@ -40,7 +40,11 @@ export default async function buildApp({ logger } = {}) {
     // pulls ~30 static assets and the log encoding cost dwarfs the serve
     // cost for the deployment's single-instance / low-traffic profile.
     // Per-route logs (errors, auth failures, deck sync) still surface.
-    disableRequestLogging: config.isProduction,
+    //
+    // Fastify 6 drops the top-level `disableRequestLogging`, so this goes
+    // through a LogController instance. The option is typed as a class but
+    // the runtime checks `instanceof`, so it has to be constructed here.
+    logController: new LogController({ disableRequestLogging: config.isProduction }),
   });
 
   // Threshold below the smallest compressible response we serve.

--- a/server/test/helpers.js
+++ b/server/test/helpers.js
@@ -18,9 +18,12 @@ const REPO_ROOT = resolve(SERVER_DIR, '..');
 // 48 chars: config.js requires at least 32 and slices the first 32 bytes.
 const TEST_SECRET = 'test-secret-0123456789abcdef0123456789abcdef0123';
 
-function prepareEnv({ demo = true } = {}) {
+function prepareEnv({ demo = true, production = false } = {}) {
   const dir = mkdtempSync(join(tmpdir(), 'couplecards-test-'));
-  process.env.NODE_ENV = 'test';
+  // `production` exists for the logging test: config.isProduction is what
+  // decides whether per-request lines are emitted, and config.js reads the
+  // environment once per process.
+  process.env.NODE_ENV = production ? 'production' : 'test';
   process.env.DATA_DIR = dir;
   process.env.DB_PATH = join(dir, 'test.db');
   process.env.SESSION_SECRET = TEST_SECRET;
@@ -56,7 +59,7 @@ export async function withDatabase(options = {}) {
 export async function withServer(options = {}) {
   const base = await withDatabase(options);
   const { default: buildApp } = await import('../src/app.js');
-  const app = await buildApp({ logger: false });
+  const app = await buildApp({ logger: options.logger ?? false });
   await app.ready();
   return {
     ...base,

--- a/server/test/logging.test.js
+++ b/server/test/logging.test.js
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// A PWA cold start pulls around thirty static assets, and encoding one access
+// log line per asset costs more than serving it on this deployment's profile,
+// so production suppresses those lines while keeping the logs that matter.
+// The setting moved from Fastify's top-level `disableRequestLogging`, which
+// Fastify 6 removes, onto a LogController instance; this pins the behavior so
+// the next major cannot silently turn the noise back on.
+
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { Writable } from 'node:stream';
+import { withServer } from './helpers.js';
+
+const lines = [];
+
+let context;
+let app;
+
+before(async () => {
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      for (const line of chunk.toString().split('\n')) {
+        if (line.trim()) lines.push(line);
+      }
+      callback();
+    },
+  });
+  context = await withServer({
+    production: true,
+    logger: { level: 'info', stream },
+  });
+  app = context.app;
+});
+
+after(() => context.cleanup());
+
+test('production emits no per-request access log line', async () => {
+  lines.length = 0;
+  const response = await app.inject({ method: 'GET', url: '/api/health' });
+  assert.equal(response.statusCode, 200);
+
+  const noise = lines.filter((line) => /incoming request|request completed/.test(line));
+  assert.deepEqual(noise, [], `production logged ${noise.length} access line(s)`);
+});
+
+test('production still logs a request the error handler sees', async () => {
+  lines.length = 0;
+  // Schema validation runs before the route guards, so an unsupported locale
+  // reaches setErrorHandler and is logged as a warning. A guard that answers
+  // 401 with reply.send() never throws and is deliberately not logged.
+  const response = await app.inject({ method: 'GET', url: '/api/cards?locale=zz' });
+  assert.equal(response.statusCode, 400);
+
+  assert.ok(
+    lines.some((line) => /"level":(40|50)/.test(line)),
+    `no warning or error line reached the log: ${lines.join(' | ')}`,
+  );
+});


### PR DESCRIPTION
Two follow-ups to the tooling pull request, both surfaced by running it.

## Fastify deprecation

The test run printed `FSTDEP023`: Fastify 5 deprecates the top-level `disableRequestLogging` and Fastify 6 removes it. Left alone, the next major would silently restore one access log line per request, and a PWA cold start pulls around thirty static assets.

The setting moves onto a `LogController` instance. Worth noting for a future reader: the option is typed as taking a class, but `createLogController` checks `instanceof`, so it has to be constructed at the call site.

## Emoji check

The cards check used to note which emoji SVGs no card references. That read as a list of dead files, and it was not one: seven of the eight are the pile and heart icons the app draws itself, and the eighth is offered by the admin form. Pure noise on every run.

It now checks the invariant that actually breaks. The admin card editor's autocomplete reads `EMOJI_SLUGS`, so an icon missing from that list ships, renders on cards that already reference it, and cannot be picked by anyone editing a card. That is exactly what happened to the desert island, ice skate and love hotel icons between 1.13.0 and 1.14.0. The check now requires the list and `public/icons/emoji/` to mirror each other, and the list to stay sorted as its own comment promises.

No file was deleted: all 137 icons are reachable today.

## Expected behaviors after merge

- Running the tests prints no deprecation warning.
- In production the server logs no per-request access line, and still logs a request the error handler sees. Two tests cover both.
- Dropping an icon from `EMOJI_SLUGS`, listing a slug with no SVG, or unsorting the list fails `npm run check:repo` with a message naming the slugs.

## Checks

- `npm run check` green (45 tests, up from 43).
- Booted with `NODE_ENV=production` on the host: `/api/health` and `/` both 200, zero access log lines, zero deprecation warnings.
